### PR TITLE
fix: Git for Windows(GitBash)のプロンプト形式を修正

### DIFF
--- a/config/git/git-prompt.sh
+++ b/config/git/git-prompt.sh
@@ -1,0 +1,34 @@
+# Git for Windows用プロンプト設定
+# ~/.config/git/git-prompt.sh として配置
+
+# Git補完とプロンプト関数を読み込み
+if test -z "$WINELOADERNOEXEC"; then
+    GIT_EXEC_PATH="$(git --exec-path 2>/dev/null)"
+    COMPLETION_PATH="${GIT_EXEC_PATH%/libexec/git-core}"
+    COMPLETION_PATH="${COMPLETION_PATH%/lib/git-core}"
+    COMPLETION_PATH="$COMPLETION_PATH/share/git/completion"
+    if test -f "$COMPLETION_PATH/git-prompt.sh"; then
+        . "$COMPLETION_PATH/git-completion.bash"
+        . "$COMPLETION_PATH/git-prompt.sh"
+    fi
+fi
+
+# Git状態表示の設定
+# * = unstaged changes    + = staged changes
+# $ = stash あり          % = untracked files
+# < = behind  > = ahead   <> = diverged  = = up-to-date
+GIT_PS1_SHOWDIRTYSTATE=1
+GIT_PS1_SHOWSTASHSTATE=1
+GIT_PS1_SHOWUNTRACKEDFILES=1
+GIT_PS1_SHOWUPSTREAM="auto"
+GIT_PS1_SHOWCONFLICTSTATE="yes"
+
+# プロンプト設定
+# 形式:
+#   user@host:path (branch *+$%<>|CONFLICT)
+#   $ (青Bold、rootは赤Bold #)
+if [ "$(id -u)" -eq 0 ]; then
+    PS1='\[\033[01;32m\]\u@\h\[\033[00m\]:\[\033[01;34m\]\w\[\033[33m\]$(__git_ps1 " (%s)")\[\033[00m\]\n\[\033[01;31m\]#\[\033[00m\] '
+else
+    PS1='\[\033[01;32m\]\u@\h\[\033[00m\]:\[\033[01;34m\]\w\[\033[33m\]$(__git_ps1 " (%s)")\[\033[00m\]\n\[\033[01;34m\]$\[\033[00m\] '
+fi

--- a/install.sh
+++ b/install.sh
@@ -252,11 +252,16 @@ remove_link() {
 install_git_files() {
     create_link "config/git/.git-completion.bash" "${HOME}/.git-completion.bash"
     create_link "config/git/.git-prompt.sh" "${HOME}/.git-prompt.sh"
+
+    # Git for Windows用プロンプト設定
+    ensure_dir "${HOME}/.config/git"
+    create_link "config/git/git-prompt.sh" "${HOME}/.config/git/git-prompt.sh"
 }
 
 uninstall_git_files() {
     remove_link "config/git/.git-completion.bash" "${HOME}/.git-completion.bash"
     remove_link "config/git/.git-prompt.sh" "${HOME}/.git-prompt.sh"
+    remove_link "config/git/git-prompt.sh" "${HOME}/.config/git/git-prompt.sh"
 }
 
 # Gitignore設定 (work/privateに応じて選択)


### PR DESCRIPTION
Git for Windowsは /etc/profile.d/git-prompt.sh で独自のPS1を設定しており、 ~/.config/git/git-prompt.sh があれば優先的に読み込む仕組みになっている。

dotfile-workのbashrcよりも先にGit for Windowsの設定が読み込まれるため、 ~/.config/git/git-prompt.sh を配置してプロンプト形式を統一する。

形式: user@host:path (branch *+$%<>|CONFLICT)$