### PR TITLE
refactor: session-start-reminder.shからDocker/Git/hookチェックを分離

### DIFF
--- a/claude/hooks/project-environment-check.sh
+++ b/claude/hooks/project-environment-check.sh
@@ -1,0 +1,119 @@
+#!/bin/sh
+# project-environment-check.sh - プロジェクト環境チェック
+#
+# 責務:
+#   - Docker環境チェック（compose/Dockerfile検出、サービス状態）
+#   - Git状態チェック（ブランチ、未コミット、未push）
+#   - hookルール出力
+#
+# 配置先: claude-config/hooks/project-environment-check.sh
+#         -> ~/.claude/hooks/project-environment-check.sh (symlink)
+
+set -eu
+
+# ═══════════════════════════════════════════════════════════════
+# Docker環境チェック
+# ═══════════════════════════════════════════════════════════════
+
+# 優先順位: compose.yml > compose.yaml > docker-compose.yml > docker-compose.yaml > Dockerfile
+HAS_COMPOSE=false
+COMPOSE_FILE=""
+
+if [ -f "compose.yml" ]; then
+    HAS_COMPOSE=true
+    COMPOSE_FILE="compose.yml"
+elif [ -f "compose.yaml" ]; then
+    HAS_COMPOSE=true
+    COMPOSE_FILE="compose.yaml"
+elif [ -f "docker-compose.yml" ]; then
+    HAS_COMPOSE=true
+    COMPOSE_FILE="docker-compose.yml"
+elif [ -f "docker-compose.yaml" ]; then
+    HAS_COMPOSE=true
+    COMPOSE_FILE="docker-compose.yaml"
+fi
+
+HAS_DOCKERFILE=false
+if [ -f "Dockerfile" ]; then
+    HAS_DOCKERFILE=true
+fi
+
+if [ "$HAS_COMPOSE" = true ] || [ "$HAS_DOCKERFILE" = true ]; then
+    echo "🐳 DOCKER ENVIRONMENT:"
+
+    # Docker daemon確認
+    if docker info > /dev/null 2>&1; then
+        echo "  Docker daemon: ✅ Running"
+
+        # Composeファイルがある場合はサービス確認
+        if [ "$HAS_COMPOSE" = true ]; then
+            echo "  Compose file: $COMPOSE_FILE"
+            RUNNING_CONTAINERS=$(docker compose ps --status running --format "{{.Service}}" 2>/dev/null | tr '\n' ' ' || echo "")
+            if [ -n "$RUNNING_CONTAINERS" ]; then
+                echo "  Running services: $RUNNING_CONTAINERS"
+            else
+                echo "  Running services: ⚠️  None (run: docker compose up -d)"
+            fi
+        fi
+
+        # Dockerfileのみの場合
+        if [ "$HAS_COMPOSE" = false ] && [ "$HAS_DOCKERFILE" = true ]; then
+            echo "  Dockerfile: ✅ Found (no compose file)"
+        fi
+    else
+        echo "  Docker daemon: ❌ Not running"
+    fi
+    echo ""
+fi
+
+# ═══════════════════════════════════════════════════════════════
+# Git状態チェック
+# ═══════════════════════════════════════════════════════════════
+
+if [ -d ".git" ]; then
+    echo "📂 GIT STATUS:"
+
+    # 現在のブランチ
+    CURRENT_BRANCH=$(git branch --show-current 2>/dev/null || echo "unknown")
+
+    # mainブランチかどうかチェック
+    if [ "$CURRENT_BRANCH" = "main" ] || [ "$CURRENT_BRANCH" = "master" ]; then
+        echo "  Branch: $CURRENT_BRANCH  🚨 WARNING: Protected branch!"
+    else
+        echo "  Branch: $CURRENT_BRANCH"
+    fi
+
+    # 未コミット変更
+    UNCOMMITTED=$(git status --porcelain 2>/dev/null | wc -l)
+    UNCOMMITTED=$((UNCOMMITTED + 0))
+    if [ "$UNCOMMITTED" -gt 0 ]; then
+        echo "  Uncommitted changes: ⚠️  $UNCOMMITTED files"
+    else
+        echo "  Uncommitted changes: ✅ None"
+    fi
+
+    # 未pushコミット
+    UPSTREAM=$(git rev-parse --abbrev-ref --symbolic-full-name @{u} 2>/dev/null || echo "")
+    if [ -n "$UPSTREAM" ]; then
+        UNPUSHED=$(git rev-list --count @{u}..HEAD 2>/dev/null || echo "0")
+        if [ "$UNPUSHED" -gt 0 ]; then
+            echo "  Unpushed commits: ⚠️  $UNPUSHED commits"
+        else
+            echo "  Unpushed commits: ✅ None"
+        fi
+    else
+        echo "  Upstream: ⚠️  Not set"
+    fi
+    echo ""
+fi
+
+# ═══════════════════════════════════════════════════════════════
+# hookルール出力（常に表示）
+# ═══════════════════════════════════════════════════════════════
+
+echo "🚫 BLOCKED ACTIONS (hooks enforced):"
+echo "  • python/node/php直接実行 → docker run --rm 使用"
+echo "  • git commit/push → ユーザーが実行"
+echo "  • sudo/admin権限 → 常に禁止"
+echo "  • mainブランチ編集 → feature branch作成"
+echo ""

--- a/claude/hooks/session-start-reminder.sh
+++ b/claude/hooks/session-start-reminder.sh
@@ -5,6 +5,7 @@
 #   - セッション開始メッセージの表示
 #   - リマインダーの表示
 #   - claude-config-info.sh の呼び出し
+#   - project-environment-check.sh の呼び出し
 #
 # 配置先: claude-config/hooks/session-start-reminder.sh
 #         -> ~/.claude/hooks/session-start-reminder.sh (symlink)
@@ -64,4 +65,10 @@ if [ -d "$SKILLS_DIR" ]; then
         fi
     done
     echo ""
+fi
+
+# プロジェクト環境チェック（Docker/Git/hookルール）
+SCRIPT_DIR=$(dirname "$0")
+if [ -x "$SCRIPT_DIR/project-environment-check.sh" ]; then
+    "$SCRIPT_DIR/project-environment-check.sh"
 fi


### PR DESCRIPTION
## Summary
- Docker環境チェック、Git状態チェック、hookルール出力を `project-environment-check.sh` に分離
- session-start-reminder.sh の責務を明確化（100行超の追加部分を別ファイルに）

## Test plan
- [ ] session-start-reminder.sh が正常に動作すること
- [ ] project-environment-check.sh が呼び出されること

🤖 Generated with [Claude Code](https://claude.ai/code)