### PR TITLE
fix: grep -c の || echo で二重出力されるバグを修正

### DIFF
--- a/claude/bin/claude-config-info.sh
+++ b/claude/bin/claude-config-info.sh
@@ -227,7 +227,8 @@ collect_skills() {
 
 print_skills_text() {
     skills=$(collect_skills)
-    count=$(echo "$skills" | grep -c . 2>/dev/null || echo "0")
+    count=$(echo "$skills" | grep -c . || true)
+    count=$((count + 0))
 
     if [ "$count" -eq 0 ] || [ -z "$skills" ]; then
         echo "  No skills found in ~/.claude/skills/"


### PR DESCRIPTION
## Summary
- `grep -c . || echo "0"` がマッチしない場合に `0\n0` を出力するバグを修正
- `|| true` と算術展開に変更

## Test plan
- [ ] claude-config-info.sh --all が正常に動作すること

🤖 Generated with [Claude Code](https://claude.ai/code)