### PR TITLE
fix(hooks): git-post-command-reminderのCWD未設定とset -eによるサイレント停止を修正

### DIFF
--- a/claude/hooks/git-post-command-reminder.sh
+++ b/claude/hooks/git-post-command-reminder.sh
@@ -6,7 +6,7 @@
 #
 # Claude Code hook として自動実行される場合は stdin から JSON を受け取る
 
-set -e
+# set -e を使わない（exit 1 = hookエラー = サイレント停止リスク）
 
 # 手動実行時のヘルプ
 if [ "$1" = "-h" ] || [ "$1" = "--help" ]; then
@@ -45,8 +45,14 @@ INPUT=$(cat)
 # jaq優先、jqフォールバック
 JQ=$(command -v jaq || command -v jq || echo "jq")
 
-# Extract command from tool_input
+# Extract command and cwd from tool_input
 COMMAND=$(echo "$INPUT" | $JQ -r '.tool_input.command // ""' 2>/dev/null || echo "")
+CWD=$(echo "$INPUT" | $JQ -r '.cwd // ""' 2>/dev/null || echo "")
+
+# CWD が指定されていればそこに移動（別プロジェクト対応）
+if [ -n "$CWD" ] && [ -d "$CWD" ]; then
+    cd "$CWD" 2>/dev/null || true
+fi
 
 # PRマージ/pull検出 - マージ済みローカルブランチを自動削除
 if echo "$COMMAND" | grep -qE '(gh\s+pr\s+merge|git\s+pull)'; then

--- a/claude/settings.json
+++ b/claude/settings.json
@@ -295,25 +295,52 @@
       {
         "matcher": "Bash",
         "hooks": [
-          { "type": "command", "command": "~/prog/dotfile-work/claude/hooks/git-commit-push-block.sh" },
-          { "type": "command", "command": "~/prog/dotfile-work/claude/hooks/docker-build-check.sh" },
-          { "type": "command", "command": "~/prog/dotfile-work/claude/hooks/language-version-check.sh" },
-          { "type": "command", "command": "~/prog/dotfile-work/claude/hooks/local-command-block.sh" },
-          { "type": "command", "command": "~/prog/dotfile-work/claude/hooks/admin-command-block.sh" },
-          { "type": "command", "command": "~/prog/dotfile-work/claude/hooks/background-command-check.sh" },
-          { "type": "command", "command": "~/prog/dotfile-work/claude/hooks/write-execute-guard.sh" }
+          {
+            "type": "command",
+            "command": "~/prog/dotfile-work/claude/hooks/git-commit-push-block.sh"
+          },
+          {
+            "type": "command",
+            "command": "~/prog/dotfile-work/claude/hooks/docker-build-check.sh"
+          },
+          {
+            "type": "command",
+            "command": "~/prog/dotfile-work/claude/hooks/language-version-check.sh"
+          },
+          {
+            "type": "command",
+            "command": "~/prog/dotfile-work/claude/hooks/local-command-block.sh"
+          },
+          {
+            "type": "command",
+            "command": "~/prog/dotfile-work/claude/hooks/admin-command-block.sh"
+          },
+          {
+            "type": "command",
+            "command": "~/prog/dotfile-work/claude/hooks/background-command-check.sh"
+          },
+          {
+            "type": "command",
+            "command": "~/prog/dotfile-work/claude/hooks/write-execute-guard.sh"
+          }
         ]
       },
       {
         "matcher": "Edit",
         "hooks": [
-          { "type": "command", "command": "~/prog/dotfile-work/claude/hooks/main-branch-code-warning.sh" }
+          {
+            "type": "command",
+            "command": "~/prog/dotfile-work/claude/hooks/main-branch-code-warning.sh"
+          }
         ]
       },
       {
         "matcher": "Write",
         "hooks": [
-          { "type": "command", "command": "~/prog/dotfile-work/claude/hooks/main-branch-code-warning.sh" }
+          {
+            "type": "command",
+            "command": "~/prog/dotfile-work/claude/hooks/main-branch-code-warning.sh"
+          }
         ]
       }
     ],
@@ -321,44 +348,80 @@
       {
         "matcher": "Bash",
         "hooks": [
-          { "type": "command", "command": "~/prog/dotfile-work/claude/hooks/branch-from-main-check.sh" },
-          { "type": "command", "command": "~/prog/dotfile-work/claude/hooks/git-post-command-reminder.sh" },
-          { "type": "command", "command": "~/prog/dotfile-work/claude/hooks/failure-check.sh" },
-          { "type": "command", "command": "~/prog/dotfile-work/claude/hooks/commit-checkpoint.sh" }
+          {
+            "type": "command",
+            "command": "~/prog/dotfile-work/claude/hooks/branch-from-main-check.sh"
+          },
+          {
+            "type": "command",
+            "command": "~/prog/dotfile-work/claude/hooks/git-post-command-reminder.sh"
+          },
+          {
+            "type": "command",
+            "command": "~/prog/dotfile-work/claude/hooks/failure-check.sh"
+          },
+          {
+            "type": "command",
+            "command": "~/prog/dotfile-work/claude/hooks/commit-checkpoint.sh"
+          }
         ]
       },
       {
         "matcher": "Edit",
         "hooks": [
-          { "type": "command", "command": "~/prog/dotfile-work/claude/hooks/doc-consistency-reminder.sh" },
-          { "type": "command", "command": "~/prog/dotfile-work/claude/hooks/hierarchical-architecture-naming-check.sh" }
+          {
+            "type": "command",
+            "command": "~/prog/dotfile-work/claude/hooks/doc-consistency-reminder.sh"
+          },
+          {
+            "type": "command",
+            "command": "~/prog/dotfile-work/claude/hooks/hierarchical-architecture-naming-check.sh"
+          }
         ]
       },
       {
         "matcher": "Write",
         "hooks": [
-          { "type": "command", "command": "~/prog/dotfile-work/claude/hooks/doc-consistency-reminder.sh" },
-          { "type": "command", "command": "~/prog/dotfile-work/claude/hooks/hierarchical-architecture-naming-check.sh" },
-          { "type": "command", "command": "~/prog/dotfile-work/claude/hooks/write-execute-guard.sh" }
+          {
+            "type": "command",
+            "command": "~/prog/dotfile-work/claude/hooks/doc-consistency-reminder.sh"
+          },
+          {
+            "type": "command",
+            "command": "~/prog/dotfile-work/claude/hooks/hierarchical-architecture-naming-check.sh"
+          },
+          {
+            "type": "command",
+            "command": "~/prog/dotfile-work/claude/hooks/write-execute-guard.sh"
+          }
         ]
       },
       {
         "hooks": [
-          { "type": "command", "command": "~/prog/dotfile-work/claude/hooks/context-monitor.sh" }
+          {
+            "type": "command",
+            "command": "~/prog/dotfile-work/claude/hooks/context-monitor.sh"
+          }
         ]
       }
     ],
     "UserPromptSubmit": [
       {
         "hooks": [
-          { "type": "command", "command": "~/prog/dotfile-work/claude/hooks/context-monitor.sh" }
+          {
+            "type": "command",
+            "command": "~/prog/dotfile-work/claude/hooks/context-monitor.sh"
+          }
         ]
       }
     ],
     "Stop": [
       {
         "hooks": [
-          { "type": "command", "command": "~/prog/dotfile-work/claude/hooks/context-monitor.sh" }
+          {
+            "type": "command",
+            "command": "~/prog/dotfile-work/claude/hooks/context-monitor.sh"
+          }
         ]
       }
     ],
@@ -377,8 +440,14 @@
     "SessionStart": [
       {
         "hooks": [
-          { "type": "command", "command": "~/prog/dotfile-work/claude/hooks/session-start-reminder.sh" },
-          { "type": "command", "command": "~/prog/dotfile-work/claude/hooks/session-resume.sh" }
+          {
+            "type": "command",
+            "command": "~/prog/dotfile-work/claude/hooks/session-start-reminder.sh"
+          },
+          {
+            "type": "command",
+            "command": "~/prog/dotfile-work/claude/hooks/session-resume.sh"
+          }
         ]
       }
     ]


### PR DESCRIPTION
- set -e を除去しサイレント停止を防止
- .cwd をJSON入力から読み取りcd（別プロジェクト対応）
- settings.json: write-execute-guard復元 + Claude Code自動整形
