### PR TITLE
fix: Git Bash環境でのシェル初期化エラーを修正

### DIFF
--- a/config/shell/bash/bashrc
+++ b/config/shell/bash/bashrc
@@ -283,13 +283,11 @@ fi
 # ============================================================================
 # ClaudeCode
 # ============================================================================
-# Workaround to prevent Claude Code from repeatedly spawning powershell.exe.
-# ref: https://github.com/anthropics/claude-code/issues/14352
-export CLAUDE_CODE_SKIP_WINDOWS_PROFILE=1
 
-if [ -d "/mnt/c/Users/$(whoami)" ]; then
-    export USERPROFILE="/mnt/c/Users/$(whoami)"
-else
-    WIN_USER=$(ls /mnt/c/Users | grep -v -E 'Public|Default|All Users|defaultuser0' | head -n1)
-    export USERPROFILE="/mnt/c/Users/$WIN_USER"
-fi
+# WSL/Git Bash: Claude Code powershell.exe 回避
+# ref: https://github.com/anthropics/claude-code/issues/14352
+case "${DOTFILES_PLATFORM:-}" in
+    wsl|windows)
+        export CLAUDE_CODE_SKIP_WINDOWS_PROFILE=1
+        ;;
+esac

--- a/config/shell/common.sh
+++ b/config/shell/common.sh
@@ -95,6 +95,51 @@ DOTFILES_PLATFORM="$(_dotfiles_detect_platform)"
 export DOTFILES_PLATFORM
 
 # ============================================================================
+# Windows連携ユーティリティ (WSL/Git Bash/Cygwin共通)
+# ============================================================================
+
+# Windowsホームディレクトリ検出 (Unix形式パスを返す)
+_dotfiles_detect_win_home() {
+    # 既に設定済みならそのまま返す
+    [ -n "${WIN_HOME:-}" ] && echo "$WIN_HOME" && return 0
+
+    case "$DOTFILES_PLATFORM" in
+        wsl)
+            # wslpath が最も確実
+            if command -v wslpath >/dev/null 2>&1; then
+                _dw_profile=$(cmd.exe /c "echo %USERPROFILE%" 2>/dev/null | tr -d '\r')
+                if [ -n "$_dw_profile" ]; then
+                    _dw_result=$(wslpath "$_dw_profile" 2>/dev/null)
+                    unset _dw_profile
+                    [ -n "$_dw_result" ] && echo "$_dw_result" && unset _dw_result && return 0
+                    unset _dw_result
+                fi
+                unset _dw_profile
+            fi
+            # フォールバック: cmd.exe でユーザー名取得
+            _dw_user=$(cmd.exe /c "echo %USERNAME%" 2>/dev/null | tr -d '\r' 2>/dev/null) || _dw_user="$(whoami)"
+            if [ -d "/mnt/c/Users/$_dw_user" ]; then
+                echo "/mnt/c/Users/$_dw_user" && unset _dw_user && return 0
+            fi
+            unset _dw_user
+            ;;
+        windows)
+            # cygpath (Git Bash/MSYS/Cygwin)
+            if command -v cygpath >/dev/null 2>&1 && [ -n "${USERPROFILE:-}" ]; then
+                cygpath "$USERPROFILE" 2>/dev/null && return 0
+            fi
+            # フォールバック: 環境変数から推定
+            _dw_user="${USERNAME:-$(whoami)}"
+            if [ -d "/c/Users/$_dw_user" ]; then
+                echo "/c/Users/$_dw_user" && unset _dw_user && return 0
+            fi
+            unset _dw_user
+            ;;
+    esac
+    return 1
+}
+
+# ============================================================================
 # PATH設定
 # ============================================================================
 
@@ -193,5 +238,6 @@ fi
 
 unset -f _dotfiles_detect_root
 unset -f _dotfiles_detect_platform
+unset -f _dotfiles_detect_win_home
 unset -f _dotfiles_add_path
 unset -f _dotfiles_load_platform

--- a/config/shell/local/windows.sh
+++ b/config/shell/local/windows.sh
@@ -1,0 +1,32 @@
+#!/bin/sh
+# shell/local/windows.sh - Git Bash (MINGW/MSYS/Cygwin) 固有設定 (POSIX互換)
+#
+# 読み込み元: common.sh (プラットフォーム検出後)
+# 対象: Git Bash on Windows (非WSL)
+
+# ============================================================================
+# Windows連携
+# ============================================================================
+
+# Windowsホームディレクトリ (common.sh の _dotfiles_detect_win_home を使用)
+WIN_HOME="${WIN_HOME:-$(_dotfiles_detect_win_home)}"
+if [ -n "$WIN_HOME" ]; then
+    WIN_USER="${WIN_USER:-$(basename "$WIN_HOME")}"
+    export WIN_USER WIN_HOME
+fi
+
+# ============================================================================
+# PATH追加 (Windows側のツール)
+# ============================================================================
+
+# Visual Studio Code (Windows版)
+if [ -n "${WIN_HOME:-}" ]; then
+    _dotfiles_add_path "$WIN_HOME/AppData/Local/Programs/Microsoft VS Code/bin" append
+fi
+
+# ============================================================================
+# エイリアス
+# ============================================================================
+
+alias open='explorer.exe'
+alias e.='explorer.exe .'

--- a/config/shell/local/wsl.sh
+++ b/config/shell/local/wsl.sh
@@ -7,11 +7,13 @@
 # Windows連携
 # ============================================================================
 
-# Windowsホームディレクトリ
-if [ -d "/mnt/c/Users" ]; then
-    WIN_USER="${WIN_USER:-$(cmd.exe /c "echo %USERNAME%" 2>/dev/null | tr -d '\r')}"
-    WIN_HOME="/mnt/c/Users/$WIN_USER"
+# Windowsホームディレクトリ (common.sh の _dotfiles_detect_win_home を使用)
+WIN_HOME="${WIN_HOME:-$(_dotfiles_detect_win_home)}"
+if [ -n "$WIN_HOME" ]; then
+    WIN_USER="${WIN_USER:-$(basename "$WIN_HOME")}"
     export WIN_USER WIN_HOME
+    # USERPROFILE: WSLでは未設定のため補完
+    export USERPROFILE="${USERPROFILE:-$WIN_HOME}"
 fi
 
 # ============================================================================
@@ -19,7 +21,9 @@ fi
 # ============================================================================
 
 # Visual Studio Code (Windows版)
-_dotfiles_add_path "/mnt/c/Users/$WIN_USER/AppData/Local/Programs/Microsoft VS Code/bin" append
+if [ -n "${WIN_HOME:-}" ]; then
+    _dotfiles_add_path "$WIN_HOME/AppData/Local/Programs/Microsoft VS Code/bin" append
+fi
 
 # ============================================================================
 # エイリアス

--- a/install.sh
+++ b/install.sh
@@ -125,7 +125,10 @@ detect_platform() {
     elif [ "$(uname)" = "Darwin" ]; then
         echo "macos"
     else
-        echo "linux"
+        case "$(uname -s)" in
+            CYGWIN*|MINGW*|MSYS*) echo "windows" ;;
+            *) echo "linux" ;;
+        esac
     fi
 }
 


### PR DESCRIPTION
- bashrcのUSERPROFILE検出が/mnt/c/Usersをハードコード問題を修正
- _dotfiles_detect_win_home()を共通ユーティリティとして追加、WSL/Git Bash/Cygwinで統一的にWindowsホームパスを解決
