### PR TITLE
fix: sshCommandの絶対パスハードコードを非修飾名に変更

### DIFF
--- a/config/git/.gitconfig.common
+++ b/config/git/.gitconfig.common
@@ -20,6 +20,7 @@
     symlinks = true
     excludesfile = ~/.gitignore_global
     compression = 1
+    sshCommand = ssh
 
 [safe]
     directory = ~/prog

--- a/install.sh
+++ b/install.sh
@@ -698,27 +698,9 @@ install_gitconfig() {
     create_link "config/git/.gitconfig.common" "${HOME}/.gitconfig.common"
     # 環境固有設定
     create_link "config/git/.gitconfig.${GITCONFIG_VARIANT}" "${HOME}/.gitconfig"
-
-    # 動的設定 (SSH)
-    SSH_CMD=$(command -v ssh 2>/dev/null || echo "ssh")
-    if [ "$MODE_DRY_RUN" = "true" ]; then
-        print_info "[ドライラン] 作成: ${HOME}/.gitconfig.local (sshCommand = ${SSH_CMD})"
-    else
-        cat > "${HOME}/.gitconfig.local" <<EOF
-# install.sh により自動生成
-[core]
-    sshCommand = ${SSH_CMD}
-EOF
-        print_success "作成: ${HOME}/.gitconfig.local (sshCommand = ${SSH_CMD})"
-    fi
 }
 
 uninstall_gitconfig() {
-    # 動的設定ファイルの削除
-    if [ -f "${HOME}/.gitconfig.local" ]; then
-        rm "${HOME}/.gitconfig.local"
-        print_success "削除: ${HOME}/.gitconfig.local"
-    fi
     # 共通設定
     remove_link "config/git/.gitconfig.common" "${HOME}/.gitconfig.common"
     # 環境固有設定


### PR DESCRIPTION
WSLで `install.sh` 実行時に `command -v ssh` の絶対パス(/usr/bin/ssh)を `.gitconfig.local` に書き込んでいたため、Git Bash環境でパスが見つからず、git pull等が失敗していた。

- .gitconfig.commonの `[core]にsshCommand = ssh` を直接記述
- install.shの動的生成処理(`cat > .gitconfig.local`)を削除
- uninstallの専用削除処理も不要となり削除
