### PR TITLE
chore: local-command-block のバージョンマネージャ過剰ブロックを修正

### DIFF
--- a/claude/hooks/local-command-block.sh
+++ b/claude/hooks/local-command-block.sh
@@ -52,7 +52,12 @@ INPUT=$(cat)
 debug_log "RAW_INPUT: $INPUT"
 
 # --- ブロック対象パターン（jqチェックより前に定義すること） ---
-BLOCKED_PATTERN='\b(python[0-9.]*|node|npm|npx|yarn|pnpm|corepack|bun|deno|php|ruby|go|perl|cargo|rustc|rustup|pip3?|uv|poetry|pipenv|conda|pyenv|virtualenv|gem|bundler?|rbenv|rvm|composer|mvn|gradlew?|sbt|dotnet|nuget|nvm|fnm|asdf|mise|volta)\b'
+# 言語ランタイム
+_BLOCKED_RUNTIME='python[0-9.]*|node|bun|deno|php|ruby|go|perl'
+# パッケージマネージャ / ビルドツール
+_BLOCKED_PACKAGE='npm|npx|yarn|pnpm|corepack|pip3?|poetry|pipenv|conda|cargo|rustc|gem|bundler?|composer|mvn|gradlew?|sbt|dotnet|nuget'
+# 注: バージョン/環境マネージャ (uv,pyenv,nvm,fnm,asdf,mise,volta等) はブロック対象外
+BLOCKED_PATTERN="\b(${_BLOCKED_RUNTIME}|${_BLOCKED_PACKAGE})\b"
 
 # jaq優先、jqフォールバック（見つからない場合は空文字）
 JQ=$(command -v jaq 2>/dev/null || command -v jq 2>/dev/null || echo "")


### PR DESCRIPTION
## Summary
- バージョン/環境マネージャ (uv, pyenv, virtualenv, rbenv, rvm, rustup, nvm, fnm, asdf, mise, volta) をブロック対象から除外
- ブロックリストをカテゴリ別 (ランタイム / パッケージマネージャ) に分割して可読性向上

## Why
- バージョンマネージャはコード実行ではなく環境管理が目的であり、ブロックは過剰
- uv がブランチ名に含まれるだけで誤検知する問題が発生していた

## Test plan
- [x] uv コマンドがブロックされないことを確認
- [x] python3, node 等のランタイムは引き続きブロックされることを確認