### PR TITLE
fix: docker-build-check.sh の誤検知と速度改善

### DIFF
--- a/claude/hooks/docker-build-check.sh
+++ b/claude/hooks/docker-build-check.sh
@@ -1,14 +1,21 @@
 #!/bin/sh
-# ビルド/インストールコマンドをDocker外で実行しようとした場合に警告
+# docker-build-check.sh - ビルド/インストールコマンドのDocker外実行を警告
+#
+# 責務:
+#   - パッケージマネージャ/ビルドツールの検知 (ツール+アクション方式)
+#   - 許可コマンドの早期判定 (case文で高速)
+#
+# 発動: PreToolUse (Bash)
+# 依存: jaq or jq
 
-# stdin からJSON入力を読み取る
+# set -e を使わない（exit 1 = hookエラー = 許可扱いリスク）
+
 if [ -t 0 ]; then
     exit 0
 fi
 
 INPUT=$(cat)
 
-# jaq優先、jqフォールバック（見つからない場合は空文字→許可）
 JQ=$(command -v jaq 2>/dev/null || command -v jq 2>/dev/null || echo "")
 if [ -n "$JQ" ]; then
     CMD=$(printf '%s\n' "$INPUT" | "$JQ" -r '.tool_input.command // ""' 2>/dev/null) || CMD=""
@@ -16,37 +23,48 @@ else
     CMD=""
 fi
 
-# コマンドが空なら即許可
-if [ -z "$CMD" ]; then
-    exit 0
-fi
+[ -z "$CMD" ] && exit 0
 
-# cdプレフィックスを考慮した許可チェック用パターン
-CD_PREFIX='^[[:space:]]*(cd[[:space:]]+[^[:space:]]+[[:space:]]*(&&|;)[[:space:]]*)*'
+# --- Fast path: case (shell built-in, subprocess なし) ---
 
-# 許可: docker / docker-compose / docker compose (コンテナ内実行)
-printf '%s\n' "$CMD" | grep -qE "${CD_PREFIX}docker[ -]" && exit 0
+# ブロック: git commit/push (git-commit-push-block.sh と二重チェック)
+case "$CMD" in
+    "git commit"|"git commit "*|*" git commit"|*" git commit "*)
+        echo "[CLAUDE.md ルール違反] git commit/push はユーザーのみ操作可能です。" >&2
+        exit 2 ;;
+    "git push"|"git push "*|*" git push"|*" git push "*)
+        echo "[CLAUDE.md ルール違反] git commit/push はユーザーのみ操作可能です。" >&2
+        exit 2 ;;
+esac
 
-# 許可: gh (GitHub CLI - 全面的に許可)
-printf '%s\n' "$CMD" | grep -qE "${CD_PREFIX}gh\b" && exit 0
+# 許可: コンテナ/CLI/VCS/システムパッケージマネージャ
+# cd prefix も && / ; チェーンで対応
+case "$CMD" in
+    docker\ *|docker-compose\ *|*"&& docker "*|*"; docker "*|*"&& docker-compose "*|*"; docker-compose "*) exit 0 ;;
+    gh\ *|glab\ *|*"&& gh "*|*"&& glab "*|*"; gh "*|*"; glab "*) exit 0 ;;
+    git\ *|*"&& git "*|*"; git "*) exit 0 ;;
+    apt\ *|apt-get\ *|brew\ *|pacman\ *|dnf\ *|yum\ *|apk\ *) exit 0 ;;
+esac
 
-# 許可: システムパッケージマネージャ (システム管理は許可)
-printf '%s\n' "$CMD" | grep -qE "${CD_PREFIX}(apt|apt-get|brew|pacman|dnf|yum|apk)\b" && exit 0
+# --- Slow path: ツール+アクション検知 (1回の grep) ---
 
-# ブロック: git commit/push (CLAUDE.mdルール: ユーザーのみ操作可能)
-if printf '%s\n' "$CMD" | grep -qE '\bgit\s+(commit|push)(\s|$)'; then
-    echo "[CLAUDE.md ルール違反] git commit/push はユーザーのみ操作可能です。" >&2
-    exit 2
-fi
+DANGEROUS='(npm|npx|yarn|pnpm|bun)\s+(install|add|ci|link|update|upgrade|build|init|rebuild)'
+DANGEROUS="$DANGEROUS|(pip|pip3|pipx)\s+(install|download|wheel)"
+DANGEROUS="$DANGEROUS|poetry\s+(install|add|update|lock|build)"
+DANGEROUS="$DANGEROUS|uv\s+(pip\s+install|sync|lock|add)"
+DANGEROUS="$DANGEROUS|gem\s+(install|update|build)"
+DANGEROUS="$DANGEROUS|bundle\s+(install|update|add)"
+DANGEROUS="$DANGEROUS|cargo\s+(install|build|add|update)"
+DANGEROUS="$DANGEROUS|go\s+(install|build|get)"
+DANGEROUS="$DANGEROUS|composer\s+(install|require|update)"
+DANGEROUS="$DANGEROUS|mvn\s+(install|compile|package|deploy)"
+DANGEROUS="$DANGEROUS|gradle\s+(build|install|compile|assemble)"
+DANGEROUS="$DANGEROUS|dotnet\s+(build|add|restore|publish)"
+DANGEROUS="$DANGEROUS|mix\s+deps\.(get|compile|update)"
+DANGEROUS="$DANGEROUS|make\s+(install|build|all)"
+DANGEROUS="$DANGEROUS|cmake\s"
 
-# 許可: git (git add等がACTIONSパターンに誤マッチするのを防止)
-# チェーンコマンド (git add && npm install) はlocal-command-block.shがnpmを検知
-printf '%s\n' "$CMD" | grep -qE "${CD_PREFIX}git\b" && exit 0
-
-# 検知: 環境を変更するアクション
-ACTIONS='install|add|build|ci|init|setup|require|update|upgrade|compile|link'
-
-if printf '%s\n' "$CMD" | grep -qE "\b($ACTIONS)\b"; then
+if printf '%s\n' "$CMD" | grep -qE "$DANGEROUS"; then
     echo "[Docker推奨] このコマンドはDocker内で実行してください。" >&2
     echo "検知: $CMD" >&2
     exit 2


### PR DESCRIPTION
- 検知方式をACTIONS語マッチからツール+アクション方式に変更(パス内のsetup/install等を誤検知しなくなる)
- 許可判定をgrep×6からcase文(built-in)に変更 (subprocess 7→2)
- glab を許可リストに追加
- git commit-graph の誤ブロックを防止

Closes #196

