### PR TITLE
fix: shell設定・install.shの小規模バグ4件を一括修正

### DIFF
--- a/config/shell/aliases.sh
+++ b/config/shell/aliases.sh
@@ -193,8 +193,8 @@ alias localip="ip route get 1 2>/dev/null | awk '{print \$7}' || ipconfig getifa
 # ============================================================================
 
 # shell/aliases.local (dotfiles管理)
-if [ -f "$DOTFILES_DIR/shell/aliases.local" ]; then
-    . "$DOTFILES_DIR/shell/aliases.local"
+if [ -f "$DOTFILES_DIR/config/shell/aliases.local" ]; then
+    . "$DOTFILES_DIR/config/shell/aliases.local"
 fi
 
 # ~/.aliases.local (Git管理外、マシン固有)

--- a/config/shell/bash/bashrc
+++ b/config/shell/bash/bashrc
@@ -132,13 +132,6 @@ fi
 # プロンプト
 # ============================================================================
 
-# Git ブランチ表示用
-if [[ -f "$HOME/.git-prompt.sh" ]]; then
-    source "$HOME/.git-prompt.sh"
-elif [[ -f "$DOTFILES_DIR/.git-prompt.sh" ]]; then
-    source "$DOTFILES_DIR/.git-prompt.sh"
-fi
-
 # oh-my-posh (インストールされていれば使用)
 _setup_oh_my_posh() {
     if ! command -v oh-my-posh &>/dev/null; then
@@ -168,7 +161,9 @@ _setup_oh_my_posh() {
     if ! eval "$(oh-my-posh init bash --config "$config")" 2>/dev/null; then
         rm -rf "$cache_dir"
         mkdir -p "$cache_dir"
-        eval "$(oh-my-posh init bash --config "$config")"
+        if ! eval "$(oh-my-posh init bash --config "$config")" 2>/dev/null; then
+            return 1
+        fi
     fi
     
     return 0

--- a/install.sh
+++ b/install.sh
@@ -909,6 +909,12 @@ uninstall_claude_config() {
         done < "$_claude_filelist"
 
         rm -f "$_claude_filelist"
+
+        # dotfiles が作成した空ディレクトリを削除 (深い順、ネスト対応)
+        # ~/.claude/ 自体は Claude Code のデータがあるため削除しない
+        find "${HOME}/.claude" -mindepth 1 -depth -type d 2>/dev/null | while IFS= read -r _dir; do
+            rmdir "$_dir" 2>/dev/null && print_success "空ディレクトリ削除: ${_dir#$HOME/}"
+        done
     fi
 }
 


### PR DESCRIPTION
- aliases.sh: aliases.local パスに config/ プレフィックス追加 (#177)
- bashrc: git-prompt.sh の重複 source を削除 (#178)
- bashrc: oh-my-posh リトライ失敗時のエラーハンドリング追加 (#179)
- install.sh: uninstall時に空ディレクトリを再帰削除 (#180)

