### PR TITLE
feat: local-command-block.sh にRunnerサブコマンド許可を追加

### DIFF
--- a/claude/global_CLAUDE.md
+++ b/claude/global_CLAUDE.md
@@ -99,11 +99,11 @@ hookを迂回するための難読化・間接実行は**絶対禁止**。
 
 **手順**:
 
-1. プロジェクトの `CLAUDE.md` を開き、指定されたリンター・型チェッカーを確認する
-2. 全てのチェッカーをDockerコンテナ内で実行する
+1. プロジェクトの `CLAUDE.md` で指定されたリンター・型チェッカー・実行環境を確認する
+2. バージョン固定された実行環境 (Docker / Runnerサブコマンド / バージョンマネージャ) でチェッカーを実行する
 3. 全てパスしたことを確認してから完了報告する
 
-未確認での完了報告は禁止。
+まず**確認**。**未確認での完了報告は禁止**。実行方法の指定がない場合はユーザーに確認する。
 
 ---
 
@@ -187,8 +187,27 @@ git-cleanup-branch           # マージ済みブランチ削除
 
 **hookで自動警告**: ビルド・テスト系は `run_in_background=true` 推奨
 
-- ローカルコマンド直接実行は禁止（hookで検知）
-- Dockerコンテナ内で実行すること: `docker run --rm` または `docker compose run --rm`
+### 実行環境の原則
+
+素のランタイム (`python3`, `node`, `bun`, `deno`, `php`, `ruby`, `go`, `perl`, `rustc`) の直接実行は**禁止** (hookで検知)。  
+理由: ローカル環境の版ズレで再現性が失われるため。
+
+**許可される実行方法**:
+
+| 方式 | 例 |
+| ------ | ------ |
+| コンテナ | `docker run --rm`, `docker compose run --rm`, `docker exec` |
+| Runnerサブコマンド | `npm run <script>`, `npm test`, `yarn build`, `pnpm run <script>`, `poetry run <cmd>`, `poetry shell`, `pipenv run <cmd>`, `cargo (run\|build\|test\|check)`, `gradle tasks`, `./gradlew build`, `sbt test`, `mvn test`, `dotnet (run\|build\|test)` |
+| バージョンマネージャ | `uv run`, `pyenv exec`, `asdf exec`, `mise exec`, `fnm exec`, `volta run` |
+
+**禁止される実行方法** (hookでブロック):
+
+| パターン | 例 |
+| ------ | ------ |
+| 素のランタイム/コンパイラ | `python3 x.py`, `node x.js`, `bun run x.ts`, `deno run x.ts`, `rustc main.rs` |
+| インストール/追加系 | `npm install`, `pip install`, `poetry add`, `cargo install`, `gem install`, `composer install` |
+
+プロジェクト `CLAUDE.md` で特定の方式が指定されている場合はそれに従う。
 
 ---
 

--- a/claude/hooks/local-command-block.sh
+++ b/claude/hooks/local-command-block.sh
@@ -31,6 +31,7 @@ local-command-block.sh - ローカル環境のコマンド実行をブロック
   Python, Node.js, PHP, Ruby, Go などのコマンドを
   Docker外で直接実行しようとした場合にブロックします。
   docker exec/run/compose 経由の実行は許可されます。
+  Runnerサブコマンド (npm run, poetry run, cargo build 等) も許可されます。
   難読化によるバイパス (base64, eval, hex, curl|sh 等) も検知します。
   チェーンコマンド (&&, ||, ;) やサブシェル $() 内のコマンドも検知します。
 
@@ -67,11 +68,38 @@ _BLOCKED_RUNTIME='python[0-9.]*|node|bun|deno|php|ruby|go|perl'
 # パッケージマネージャ / ビルドツール
 _BLOCKED_PACKAGE='npm|npx|yarn|pnpm|corepack|pip3?|poetry|pipenv|conda|cargo|rustc|gem|bundler?|composer|mvn|gradlew?|sbt|dotnet|nuget'
 # 注: バージョン/環境マネージャ (uv,pyenv,nvm,fnm,asdf,mise,volta等) はブロック対象外
+# 注: 上記でも is_runner_command にマッチする場合 (npm run, poetry run 等) は許可
 BLOCKED_EXACT="^(${_BLOCKED_RUNTIME}|${_BLOCKED_PACKAGE})$"
 
 # --- Docker経由かチェックする関数 ---
 is_docker_command() {
     printf '%s\n' "$1" | grep -qE '^\s*(cd\s+[^;&|]+\s*(&&|;)\s*)*(docker\s+(exec|run|compose)|docker-compose)\b'
+}
+
+# --- Runner系サブコマンドかチェックする関数 ---
+# プロジェクト紐付きのビルド/実行系 (npm run, poetry run, cargo build 等) を許可
+# インストール系 (npm install, poetry add, cargo install 等) は許可しない
+# パス付き (/usr/bin/npm, ./gradlew) / env prefix (FOO=bar npm) も get_first_command で吸収
+is_runner_command() {
+    _ir_cmd=$(get_first_command "$1")
+    case "$_ir_cmd" in
+        npm|yarn|pnpm|poetry|pipenv|cargo|gradle|gradlew|sbt|dotnet|mvn) ;;
+        *) return 1 ;;
+    esac
+    # コマンド名直後のトークン (サブコマンド) を抽出
+    _ir_sub=$(printf '%s' "$1" | awk -v cmd="$_ir_cmd" '
+        BEGIN { found = 0 }
+        {
+            for (i=1; i<=NF; i++) {
+                if (found) { print $i; exit }
+                n = split($i, parts, "/")
+                if (parts[n] == cmd) { found = 1 }
+            }
+        }')
+    case "$_ir_sub" in
+        run|exec|test|build|start|check|tasks|shell) return 0 ;;
+        *) return 1 ;;
+    esac
 }
 
 # --- コマンドセグメントから実行コマンド名を抽出 ---
@@ -101,6 +129,10 @@ check_segment() {
     _seg="$1"
     [ -z "$_seg" ] && return 0
     if is_docker_command "$_seg"; then
+        return 0
+    fi
+    if is_runner_command "$_seg"; then
+        debug_log "RUNNER_COMMAND: 許可 $_seg"
         return 0
     fi
     _cmd=$(get_first_command "$_seg")

--- a/tests/test_hooks.sh
+++ b/tests/test_hooks.sh
@@ -165,35 +165,37 @@ run_local_test() {
 echo ""
 echo "--- ブロックすべきコマンド (exit 2) ---"
 
-# 直接実行
+# 直接実行 (ランタイム / 直接コンパイラ)
 run_local_test "python3 script.py" "$(make_input 'python3 script.py')" 2
 run_local_test "node server.js" "$(make_input 'node server.js')" 2
-run_local_test "npm install" "$(make_input 'npm install')" 2
 run_local_test "go build" "$(make_input 'go build')" 2
-run_local_test "pip install flask" "$(make_input 'pip install flask')" 2
-run_local_test "cargo build" "$(make_input 'cargo build')" 2
-run_local_test "yarn add express" "$(make_input 'yarn add express')" 2
 run_local_test "ruby script.rb" "$(make_input 'ruby script.rb')" 2
 run_local_test "bun run dev" "$(make_input 'bun run dev')" 2
 run_local_test "deno run server.ts" "$(make_input 'deno run server.ts')" 2
 run_local_test "php -r echo" "$(make_input 'php -r \"echo 1;\"')" 2
 run_local_test "perl -e print" "$(make_input 'perl -e \"print 1\"')" 2
+run_local_test "rustc main.rs" "$(make_input 'rustc main.rs')" 2
+run_local_test "bare: go" "$(make_input 'go')" 2
+run_local_test "python3 --version" "$(make_input 'python3 --version')" 2
+
+# インストール/パッケージ追加系 (プロジェクト外汚染リスクあるため継続ブロック)
+run_local_test "npm install" "$(make_input 'npm install')" 2
+run_local_test "pip install flask" "$(make_input 'pip install flask')" 2
+run_local_test "yarn add express" "$(make_input 'yarn add express')" 2
 run_local_test "poetry install" "$(make_input 'poetry install')" 2
+run_local_test "poetry add numpy" "$(make_input 'poetry add numpy')" 2
+run_local_test "cargo install ripgrep" "$(make_input 'cargo install ripgrep')" 2
 run_local_test "composer install" "$(make_input 'composer install')" 2
 run_local_test "npx create-app" "$(make_input 'npx create-app')" 2
 run_local_test "pnpm install" "$(make_input 'pnpm install')" 2
 run_local_test "pipenv install" "$(make_input 'pipenv install')" 2
 run_local_test "conda install numpy" "$(make_input 'conda install numpy')" 2
-run_local_test "rustc main.rs" "$(make_input 'rustc main.rs')" 2
 run_local_test "mvn clean install" "$(make_input 'mvn clean install')" 2
 run_local_test "sbt compile" "$(make_input 'sbt compile')" 2
-run_local_test "dotnet build" "$(make_input 'dotnet build')" 2
 run_local_test "nuget restore" "$(make_input 'nuget restore')" 2
 run_local_test "bundler install" "$(make_input 'bundler install')" 2
 run_local_test "gem install rails" "$(make_input 'gem install rails')" 2
 run_local_test "corepack enable" "$(make_input 'corepack enable')" 2
-run_local_test "bare: go" "$(make_input 'go')" 2
-run_local_test "python3 --version" "$(make_input 'python3 --version')" 2
 
 # フルパス
 run_local_test "/usr/bin/python3 script.py" "$(make_input '/usr/bin/python3 script.py')" 2
@@ -270,6 +272,31 @@ run_local_test "docker run python3" "$(make_input 'docker run --rm python:3.12 p
 run_local_test "docker compose npm" "$(make_input 'docker compose run --rm test npm test')" 0
 run_local_test "docker exec node" "$(make_input 'docker exec container node app.js')" 0
 run_local_test "cd && docker run npm" "$(make_input 'cd /project && docker run --rm node:18 npm install')" 0
+
+# Runnerサブコマンド経由 (プロジェクト紐付きビルド/実行)
+run_local_test "npm run dev" "$(make_input 'npm run dev')" 0
+run_local_test "npm test" "$(make_input 'npm test')" 0
+run_local_test "npm start" "$(make_input 'npm start')" 0
+run_local_test "yarn test" "$(make_input 'yarn test')" 0
+run_local_test "pnpm run build" "$(make_input 'pnpm run build')" 0
+run_local_test "poetry run python" "$(make_input 'poetry run python script.py')" 0
+run_local_test "poetry shell" "$(make_input 'poetry shell')" 0
+run_local_test "pipenv run flask" "$(make_input 'pipenv run flask run')" 0
+run_local_test "cargo run" "$(make_input 'cargo run')" 0
+run_local_test "cargo build" "$(make_input 'cargo build')" 0
+run_local_test "cargo test" "$(make_input 'cargo test')" 0
+run_local_test "cargo check" "$(make_input 'cargo check')" 0
+run_local_test "gradle tasks" "$(make_input 'gradle tasks')" 0
+run_local_test "gradlew build" "$(make_input './gradlew build')" 0
+run_local_test "sbt test" "$(make_input 'sbt test')" 0
+run_local_test "mvn test" "$(make_input 'mvn test')" 0
+run_local_test "dotnet run" "$(make_input 'dotnet run')" 0
+run_local_test "dotnet build" "$(make_input 'dotnet build')" 0
+run_local_test "dotnet test" "$(make_input 'dotnet test')" 0
+run_local_test "cd && npm run dev" "$(make_input 'cd /app && npm run dev')" 0
+run_local_test "./gradlew build" "$(make_input './gradlew build')" 0
+run_local_test "/usr/bin/npm run" "$(make_input '/usr/bin/npm run dev')" 0
+run_local_test "FOO=bar npm test" "$(make_input 'FOO=bar npm test')" 0
 
 # サブシェル内の安全なコマンド
 run_local_test "echo \$(cat go.sum)" "$(make_input 'echo \$(cat go.sum)')" 0


### PR DESCRIPTION
- is_runner_command 関数を追加し、プロジェクト紐付きの実行コマンド (`npm run/test, poetry run/shell, cargo run/build/test/check,mvn/gradle/sbt/dotnet の run|exec|test|build|start|check|tasks|shell`) を許可
- インストール系 (`npm install, poetry add, cargo install` 等) は継続ブロック
- パス付き `(./gradlew) / env prefix (FOO=bar npm)` は `get_first_command` で正規化
- `tests/test_hooks.sh` に Runner許可21件+パス/env prefix3件を追加 (180/180 pass)
- `global_CLAUDE.md` の静的解析・Bash実行ルールセクションを案2準拠で更新
- ヘルプテキスト・BLOCKED_PACKAGE コメントにも `Runner` 例外を明記