### PR TITLE
chore: empirical-prompt-tuning 用 tuning-logs 基盤を追加

### DIFF
--- a/docs/tuning-logs/README.md
+++ b/docs/tuning-logs/README.md
@@ -1,0 +1,108 @@
+# Tuning Logs
+
+`empirical-prompt-tuning` skill で各スキルをチューニングした際の評価ログ置き場。
+
+- 手法: [`claude/skills/empirical-prompt-tuning/SKILL.md`](../../claude/skills/empirical-prompt-tuning/SKILL.md)
+- 全体計画: `~/.claude/plans/empirical-prompt-tuning-skill-atomic-wadler.md`
+
+## 配置が `claude/` 外である理由
+
+`install.sh` は `git ls-files claude/` で `claude/` 配下の tracked ファイルを `~/.claude/` にシンボリックリンクする。チューニングログを `claude/skills/<name>/tuning/` に置くと `~/.claude/skills/<name>/tuning/` に配布され、将来の subagent が skill autoload でログを読み込んでバイアス汚染する恐れがある（empirical-prompt-tuning「同一 subagent 使い回し禁止」と同精神）。
+
+`docs/` 配下なら `install.sh` が拾わないため、リポジトリ資産として保持しつつ `~/.claude/` を汚さない。
+
+## ディレクトリ構造
+
+```
+docs/tuning-logs/
+├── README.md                  # 本ファイル
+├── trigger-overlap.md         # 全スキルの description 重なり語表（Phase 0 成果物）
+└── <skill-name>/
+    ├── scenarios.md           # baseline 3 本 + hold-out 1 本。iter 中は変更禁止
+    ├── iter-0.md              # description/body 整合チェック（静的、dispatch なし）
+    ├── iter-1.md              # baseline 評価（3 シナリオ並列 dispatch）
+    ├── iter-2.md              # 1 テーマ修正後の再評価
+    └── iter-N.md              # 連続2（重要スキル3）クリアまで
+```
+
+## `scenarios.md` フォーマット
+
+```markdown
+# <skill-name> シナリオカタログ
+
+## Baseline シナリオ
+
+### シナリオA（中央値）
+- **状況**: <1 段落>
+- **要件チェックリスト**（○/×/部分的で判定、[critical] は最低1つ必須）:
+  1. [critical] <最低ライン>
+  2. <通常項目>
+  ...
+
+### シナリオB（edge 1）
+...
+
+### シナリオC（edge 2）
+...
+
+## Hold-out シナリオ（収束判定時のみ使用）
+
+### シナリオD
+...
+```
+
+## `iter-N.md` フォーマット
+
+empirical-prompt-tuning「提示フォーマット」節準拠。
+
+```markdown
+# iter N — <skill-name>
+
+## 変更点（前回差分）
+- <修正内容 1 行>
+
+## 実行結果（シナリオ別）
+| シナリオ | 成功/失敗 | 精度 | steps | duration | retries |
+|---|---|---|---|---|---|
+| A | ○ | 90% | 4 | 20s | 0 |
+| B | × | 60% | 9 | 41s | 2 |
+
+## 不明瞭点（今回新出）
+- シナリオ B: [critical] 項目 N が × — <落ちた理由 1 行>
+- シナリオ B: <その他の指摘>
+
+## 裁量補完（今回新出）
+- シナリオ B: <補完内容>
+
+## empirical-prompt-tuning 側の曖昧点
+（対象 skill ではなく empirical-prompt-tuning 自身の記述で subagent が詰まった箇所があれば記録。Phase 4 の入力になる）
+
+## 次の修正案
+- <最小修正 1 行>
+
+## 収束判定
+- 連続 X 回クリア / 停止条件まであと Y 回
+- hold-out 結果（最終 iter のみ）: 直近平均から -N pt
+```
+
+## 運用ルール
+
+| ルール | 理由 |
+|---|---|
+| シナリオは iter 開始後に変更しない | チューニングが「シナリオ側を簡単にする」方向に走るのを防ぐ |
+| subagent は iter ごとに新規 dispatch | 前回の改善を学習したエージェントは評価に使えない |
+| 1 iter = 1 テーマ修正 | 何が効いたか追えなくなるのを防ぐ（関連微修正はまとめて OK） |
+| `[critical]` タグ最低1つ | 成功判定が vacuous になるのを防ぐ |
+| hold-out は収束判定時のみ使用 | 過適合チェック用。途中 iter で使うと「見えてしまう」 |
+| subagent 起動時に他 skill auto-load を禁止 | 対象 skill 以外の recipe で動かれると評価が成立しない |
+| 対象が配布パッケージ（例: qa-nightmare + `checklists/`）なら全ファイル参照指示 | SKILL.md 単独評価だと false positive |
+
+## 収束判定（empirical-prompt-tuning L128-133）
+
+連続 2 イテレーション（重要スキルは連続 3）で **全て** 満たす:
+
+- 新規不明瞭点 0
+- 精度の前回比改善 +3pt 以下
+- ステップ数の前回比変動 ±10% 以内
+- duration の前回比変動 ±15% 以内
+- hold-out シナリオで直近平均から -15pt 以内

--- a/docs/tuning-logs/trigger-overlap.md
+++ b/docs/tuning-logs/trigger-overlap.md
@@ -1,0 +1,58 @@
+# Trigger 重なり語表
+
+全11スキルの `description`（frontmatter）から **複数スキルに登場する語** を抽出。各スキル iter 0 の「直前スキルとの重なり語チェック」の補助データとして使用する。
+
+## 抽出元
+
+`claude/skills/<name>/SKILL.md` の frontmatter `description:` フィールドのみ（body は対象外）。
+
+## 重なり語一覧
+
+| 語 | 登場スキル | 危険度 | 境界の整理方針 |
+|---|---|:---:|---|
+| **テスト** | tdd / test-coverage-guard / e2e-browser / qa-nightmare / systematic-debugging | 🔴 高 | tdd=作成、test-coverage-guard=GREEN後検証、e2e-browser=ブラウザ実行基盤、qa-nightmare=悪夢ケース生成、systematic-debugging=テスト失敗の診断。**各 description に「この skill がカバーしない隣接領域」を明示する候補** |
+| **実装** | consultation / interface-first-design / tdd | 🟡 中 | consultation=判断相談、iface-first=設計→実装接続、tdd=テスト駆動実装 |
+| **設計** | consultation / interface-first-design | 🟡 中 | consultation=技術選定・判断相談、iface-first=interface/クラス設計（実装直前） |
+| **機能** | interface-first-design / tdd | 🟡 中 | iface-first=機能追加の設計段階、tdd=機能実装の RED-GREEN-REFACTOR |
+| **修正 / バグ** | systematic-debugging / tdd | 🟡 中 | systematic-debugging=原因分析、tdd=修正実装（境界はある程度明確） |
+| **失敗** | failure-logging / systematic-debugging | 🟢 低 | failure-logging=記録、systematic-debugging=分析 |
+| **改善** | refactoring / empirical-prompt-tuning | 🟢 低 | refactoring=コード構造改善、empirical=プロンプト改善。対象ドメインが別 |
+| **構造** | refactoring / consultation | 🟢 低 | refactoring=コード構造、consultation=問題構造化（異義） |
+
+## 🔴 高リスク: 「テスト」の扱い
+
+**subagent 視点で「テストを書いて」と言われたときに迷う最大の要因。**
+
+現状 description からは以下の判別が困難:
+
+| シナリオ | 選ぶべき skill | 現 description からの読み取りやすさ |
+|---|---|:---:|
+| 新機能のユニットテストを RED から書く | tdd | ○ |
+| 既存の GREEN テストが本当にバグを検出できるか確認したい | test-coverage-guard | △（「信頼性を検証」は分かるが他と被る） |
+| ブラウザで DB 更新まで含めて動作確認したい | e2e-browser | ○（E2E が明確） |
+| このフォームの QA が嫌がりそうな edge を列挙したい | qa-nightmare | ○（悪夢ケースが明確） |
+| テストが落ちた原因を知りたい | systematic-debugging | △（「テスト失敗に遭遇」は分かるが tdd と被る） |
+
+**推奨アクション（各スキル iter 0 の整合チェック時）**:
+- test-coverage-guard: description に「tdd がテスト作成、本 skill は作成済テストの検証」を明示
+- systematic-debugging: description に「tdd が修正実装、本 skill は修正**前**の原因分析」を明示
+- tdd: description に「既存テストの検証は test-coverage-guard」の一言を足す候補
+
+## 🟡 中リスク: 「実装 / 設計 / 機能」
+
+consultation / interface-first-design / tdd の **phase** 関係で整理できる:
+
+```
+consultation（迷い/相談）  →  interface-first-design（設計）  →  tdd（テスト駆動実装）
+```
+
+各 description に phase 位置を明示する余地あり。interface-first-design には既に「TDDスキルの前段」の記載があり好例。
+
+## 🟢 低リスク: 「失敗 / 改善 / 構造」
+
+対象ドメイン（エラー vs プロンプト / コード vs 問題）が異なるため subagent の判断は容易。iter 1 の baseline 評価で問題が出た場合のみ対応。
+
+## 運用
+
+- 本ファイルは **Phase 0 時点のスナップショット**。各スキルの description を改訂したら本ファイルも更新する（該当スキルの PR に含める）
+- 各スキル iter 0 で「本表の該当行を確認 → 重なりが body 側で整合しているか」をチェック


### PR DESCRIPTION
全11スキルを empirical-prompt-tuning でチューニングするための評価ログ格納先を `docs/tuning-logs/` に新設。

- README.md: 運用ルール、`scenarios/iter-N` のフォーマット、収束判定
- trigger-overlap.md: 全スキル `description` の重なり語分析(「テスト」が5スキルに跨る最大の境界問題を特定)
