### PR TITLE
fix: Stop hook の実ユーザーターン誤判定を修正 (block→warning)

### DIFF
--- a/claude/hooks/completion-claim-check.sh
+++ b/claude/hooks/completion-claim-check.sh
@@ -1,14 +1,15 @@
 #!/bin/sh
-# completion-claim-check.sh - テスト pass ログ無しの完了報告をブロック (Stop)
+# completion-claim-check.sh - テスト pass ログ無しの完了報告を警告 (Stop)
 #
 # 責務:
 #   - 直近の実ユーザーターン以降の応答に「完了報告」表現があり、かつ
-#     同区間にテスト実行の痕跡 (Bash tool_use) が無い場合に停止をブロックする
+#     同区間にテスト実行の痕跡 (Bash tool_use) が無い場合に警告する (停止はブロックしない)
 #   - global_CLAUDE.md「テスト pass のログを示してから完了報告する」と整合させる
+#   - 実ユーザーターン判定では isMeta 行とハーネス注入 (task-notification 等) を除外する
 #
-# 出力: 該当時のみ {"decision":"block","reason":...} を返す。それ以外は exit 0
-# ループ防止: stop_hook_active が true の場合は判定を skip (二重発火しない)
-# 依存: jaq or jq, perl
+# 出力: 該当時のみ {"systemMessage":...} を返す。それ以外は exit 0
+# 二重発火抑制: stop_hook_active が true の場合は判定を skip
+# 依存: jaq or jq
 #
 # 配置先: ~/.claude/hooks/completion-claim-check.sh
 
@@ -41,9 +42,14 @@ EXTRACT=$(tail -300 "$TRANSCRIPT_PATH" | "$JQ" -s -r '
     [ .[] | select(.isSidechain != true) ] as $rows
     | ( [ $rows | to_entries[]
           | select(.value.type == "user"
-              and ((.value.message.content | type) == "string"
-                   or ((.value.message.content | type) == "array"
-                       and (.value.message.content | map(.type) | any(. == "text")))))
+              and (.value.isMeta != true)
+              and (.value.message.content as $c | ($c | type) as $ct
+                   | ($ct == "string"
+                      and (($c | (startswith("<task-notification>")
+                                  or startswith("Stop hook feedback:")
+                                  or startswith("Your tool call was malformed")
+                                  or startswith("[Request interrupted"))) | not))
+                     or ($ct == "array" and ($c | map(.type) | any(. == "text")))))
           | .key ] | (.[-1]) ) as $u
     | (($u // -1) + 1) as $start
     | $rows[$start:] as $resp
@@ -88,9 +94,9 @@ if [ "$HAS_TEST" -eq 1 ]; then
     exit 0
 fi
 
-# --- テスト痕跡無しの完了報告 → ブロック ---
-REASON="完了報告「${CLAIM}」を検出しましたが、直近の応答にテスト/検証コマンドの実行痕跡がありません。global_CLAUDE.md の方針: テスト pass のログを示してから完了報告する。未確認の完了報告は禁止です。テストを実行して pass を確認するか、検証をスキップした理由を明示してください。"
+# --- テスト痕跡無しの完了報告 → 警告 (停止はブロックしない) ---
+MSG="⚠️ [完了報告チェック] 完了報告「${CLAIM}」を検出しましたが、直近の応答にテスト/検証コマンドの実行痕跡がありません。global_CLAUDE.md の方針: テスト pass のログを示してから完了報告する。テストを実行して pass を確認するか、検証をスキップした理由を明示してください。"
 
-printf '%s' "$REASON" | "$JQ" -R -s '{decision: "block", reason: .}' 2>/dev/null || exit 0
+printf '%s' "$MSG" | "$JQ" -R -s '{systemMessage: .}' 2>/dev/null || exit 0
 
 exit 0

--- a/claude/hooks/sycophancy-check.sh
+++ b/claude/hooks/sycophancy-check.sh
@@ -36,9 +36,14 @@ HEAD=$(tail -200 "$TRANSCRIPT_PATH" | "$JQ" -s -r '
     [ .[] | select(.isSidechain != true) ] as $rows
     | ( [ $rows | to_entries[]
           | select(.value.type == "user"
-              and ((.value.message.content | type) == "string"
-                   or ((.value.message.content | type) == "array"
-                       and (.value.message.content | map(.type) | any(. == "text")))))
+              and (.value.isMeta != true)
+              and (.value.message.content as $c | ($c | type) as $ct
+                   | ($ct == "string"
+                      and (($c | (startswith("<task-notification>")
+                                  or startswith("Stop hook feedback:")
+                                  or startswith("Your tool call was malformed")
+                                  or startswith("[Request interrupted"))) | not))
+                     or ($ct == "array" and ($c | map(.type) | any(. == "text")))))
           | .key ] | (.[-1]) ) as $u
     | (($u // -1) + 1) as $start
     | [ $rows[$start:][]

--- a/tests/test_hooks.sh
+++ b/tests/test_hooks.sh
@@ -382,11 +382,11 @@ run_output_test "根拠ある応答 → 無警告" "$SYCO" \
 {\"type\":\"assistant\",\"message\":{\"role\":\"assistant\",\"content\":[{\"type\":\"text\",\"text\":\"3点指摘します。1つ目は型定義です。\"}]},\"isSidechain\":false}" \
 ""
 
-echo "--- completion: テスト痕跡なし完了報告 → block ---"
-run_output_test "完了報告+テストなし → block" "$COMP" \
+echo "--- completion: テスト痕跡なし完了報告 → 警告 ---"
+run_output_test "完了報告+テストなし → 警告" "$COMP" \
 "$USER_LINE
 {\"type\":\"assistant\",\"message\":{\"role\":\"assistant\",\"content\":[{\"type\":\"text\",\"text\":\"実装しました。\"}]},\"isSidechain\":false}" \
-"\"decision\": \"block\""
+"完了報告チェック"
 
 echo "--- completion: テスト痕跡あり → 許可 ---"
 run_output_test "完了報告+テストあり → 無出力" "$COMP" \
@@ -406,10 +406,18 @@ run_output_test "実証できました → 無出力 (誤検知回避)" "$COMP" 
 "$USER_LINE
 {\"type\":\"assistant\",\"message\":{\"role\":\"assistant\",\"content\":[{\"type\":\"text\",\"text\":\"gitignore の出典を実証できました。\"}]},\"isSidechain\":false}" \
 ""
-run_output_test "実装できました+テストなし → block (限定形)" "$COMP" \
+run_output_test "実装できました+テストなし → 警告 (限定形)" "$COMP" \
 "$USER_LINE
 {\"type\":\"assistant\",\"message\":{\"role\":\"assistant\",\"content\":[{\"type\":\"text\",\"text\":\"機能を実装できました。\"}]},\"isSidechain\":false}" \
-"\"decision\": \"block\""
+"完了報告チェック"
+
+echo "--- completion: ハーネス注入行を実ユーザー誤判定しない (root cause 回帰) ---"
+run_output_test "task-notification で区間が切れない → 無出力" "$COMP" \
+"$USER_LINE
+{\"type\":\"assistant\",\"message\":{\"role\":\"assistant\",\"content\":[{\"type\":\"tool_use\",\"name\":\"Bash\",\"input\":{\"command\":\"docker compose -f tests/compose.yml run --rm hooks-test\"}}]},\"isSidechain\":false}
+{\"type\":\"user\",\"isMeta\":false,\"message\":{\"role\":\"user\",\"content\":\"<task-notification>\\n<task-id>x</task-id> completed\"}}
+{\"type\":\"assistant\",\"message\":{\"role\":\"assistant\",\"content\":[{\"type\":\"text\",\"text\":\"実装しました。\"}]},\"isSidechain\":false}" \
+""
 
 echo "--- completion: ループ防止 (stop_hook_active=true) → 許可 ---"
 run_output_test "stop_hook_active → 無出力" "$COMP" \


### PR DESCRIPTION
ハーネス注入の user 行 (<task-notification> / Stop hook feedback / isMeta:true) を実ユーザー入力と誤判定し、判定区間が切り詰められテスト痕跡が脱落する問題を修正。

- completion-claim-check / sycophancy の user-turn セレクタに isMeta + 注入プレフィックス除外を追加
- completion は文脈依存判定の誤検知害を避け block→warning に格下げ
- root cause 回帰テスト追加 (Docker 190/190 passed)
