### PR TITLE
fix: failure-log フックを Stop 契機へ移行し失敗コマンドを記録

### DIFF
--- a/claude/hooks/failure-log.sh
+++ b/claude/hooks/failure-log.sh
@@ -1,34 +1,79 @@
 #!/usr/bin/env bash
-# PostToolUse (matcher: Bash) フック。
-# Bash コマンドが失敗 (非ゼロ終了) した際、failure_log に自動で記録する。
-# 「コマンドエラーの捕捉」を決定論的に担当し、判断を要する分析・原因記入・
-# 解決マークは failure-logging スキルが行う。
+# Stop フック。ターン終了時に transcript JSONL を読み、失敗した Bash コマンド
+# (tool_result.is_error == true) を failure_log に自動記録する。
+#
+# WHY Stop か: PostToolUse[Bash] は失敗コマンドで発火せず、tool_response にも
+# 終了コードが無い (2026-06-05 実証)。失敗は transcript の is_error にのみ残る。
+#
+# WHY 増分読み: Stop は毎ターン発火する。transcript はセッション中に単調増加
+# するため、毎回全読みすると累積 O(ターン数^2) になる。前回処理済みのバイト位置
+# (offset) を保存し新規追記分だけ読むことで、各ターン O(Δ)・累積 O(N) に抑える。
+#
+# 捕捉のみを担当。分析・原因記入・解決マークは failure-logging スキルが行う。
 set -euo pipefail
 
 LOG_DIR="claude_tmp/failure_log"
 LOG_FILE="${LOG_DIR}/auto-fail.log"
+OFFSET_FILE="${LOG_DIR}/.transcript-offset"
+RESULT_TAIL_CHARS=300
 
-# PostToolUse のペイロードを stdin から受け取る。
-payload="$(cat)"
+transcript_path="$(jq -r '.transcript_path // empty')" \
+  || { printf '[failure-log] payload parse failed\n' >&2; exit 0; }
+[ -n "${transcript_path}" ] || exit 0
 
-# tool_response から終了コード・コマンド・エラー出力を取り出す。
-# フィールド名は Claude Code のバージョンで異なる場合がある。
-# 動かない場合は jq のパスを実環境のペイロードに合わせて調整すること。
-exit_code="$(printf '%s' "$payload" | jq -r '.tool_response.exit_code // .tool_response.exitCode // empty' 2>/dev/null || true)"
-command="$(printf '%s' "$payload" | jq -r '.tool_input.command // empty' 2>/dev/null || true)"
-stderr_tail="$(printf '%s' "$payload" | jq -r '.tool_response.stderr // .tool_response.output // empty' 2>/dev/null | tail -c 500 || true)"
-
-# 終了コードが取得できない、または 0 の場合は何もしない。
-[ -z "${exit_code}" ] && exit 0
-[ "${exit_code}" = "0" ] && exit 0
+# realpath はシンボリックリンク攻撃 (TOCTOU) 緩和の best-effort。未導入環境では
+# 生パスにフォールバックし、hook 自体は止めない。
+resolved="$(realpath -- "${transcript_path}" 2>/dev/null || true)"
+[ -n "${resolved}" ] && transcript_path="${resolved}"
+[ -f "${transcript_path}" ] || exit 0
 
 mkdir -p "${LOG_DIR}"
-{
-  printf -- '---\n'
-  printf 'time: %s\n' "$(date -Iseconds)"
-  printf 'exit: %s\n' "${exit_code}"
-  printf 'command: %s\n' "${command}"
-  printf 'stderr_tail: %s\n' "${stderr_tail}"
-} >> "${LOG_FILE}"
+touch "${LOG_FILE}"
 
+# 前回処理済みバイト位置を読む。破損値・transcript 縮小 (別セッション) は先頭から。
+current_size="$(wc -c < "${transcript_path}")"
+offset=0
+if [ -f "${OFFSET_FILE}" ]; then
+  offset="$(cat "${OFFSET_FILE}")"
+  case "${offset}" in *[!0-9]*) offset=0 ;; esac
+fi
+[ "${current_size}" -lt "${offset}" ] && offset=0
+[ "${current_size}" -eq "${offset}" ] && exit 0   # 新規追記なし
+
+new_data="$(tail -c "+$((offset + 1))" "${transcript_path}")"
+[ -n "${new_data}" ] || { printf '%s' "${current_size}" > "${OFFSET_FILE}"; exit 0; }
+
+# 新規分から失敗 Bash を抽出 (jq 1 回・TSV 出力)。tool_use(Bash) の id->command と
+# tool_result(is_error) を tool_use_id で突き合わせ、command と結果を 1 行に整形する。
+# 秘密混入時の二重露出を防ぐため key/token 類を <redacted> にマスクする (best-effort)。
+# jq 失敗 (末尾の不完全行等) は offset を進めず次ターンで再試行する。
+failures="$(printf '%s' "${new_data}" | jq -rs --argjson limit "${RESULT_TAIL_CHARS}" '
+  def mask: gsub("(?i)(api[_-]?key|secret|token|password|passwd|bearer|authorization)\\s*[=:]?\\s*\\S+"; "<redacted>");
+  (map(select(.type == "assistant") | .message.content[]?
+       | select(.type == "tool_use" and .name == "Bash") | {(.id): .input.command})
+   | add // {}) as $cmds
+  | map(select(.type == "user")
+        | .toolUseResult as $tur
+        | (.message.content[]? | select(.type == "tool_result" and (.is_error == true))) as $tr
+        | select($cmds | has($tr.tool_use_id))
+        | [ $tr.tool_use_id,
+            ($cmds[$tr.tool_use_id] // "" | mask | gsub("[\t\n]+"; " ")),
+            ($tur | tostring | mask | gsub("[\t\n]+"; " ") | .[0:$limit]) ]
+        | @tsv)
+  | .[]
+')" || { printf '[failure-log] transcript parse failed (incomplete line?); retry next turn\n' >&2; exit 0; }
+
+now="$(date -Iseconds)"
+# LOG_FILE への append はループ末尾で 1 回だけ open する (失敗 1 件ごとの再 open を避ける)。
+while IFS=$'\t' read -r id command result_tail; do
+  [ -n "${id}" ] || continue
+  printf -- '---\n'
+  printf 'time: %s\n' "${now}"
+  printf 'id: %s\n' "${id}"
+  printf 'command: %s\n' "${command}"
+  printf 'result_tail: %s\n' "${result_tail}"
+done <<< "${failures}" >> "${LOG_FILE}"
+
+# このバイト範囲は処理済み。次ターンはここから読む (重複記録を offset で防ぐ)。
+printf '%s' "${current_size}" > "${OFFSET_FILE}"
 exit 0

--- a/claude/settings.json
+++ b/claude/settings.json
@@ -91,10 +91,6 @@
           },
           {
             "type": "command",
-            "command": "~/.claude/hooks/failure-log.sh"
-          },
-          {
-            "type": "command",
             "command": "~/.claude/hooks/post-cleanup-notes-archive.sh",
             "timeout": 10
           }
@@ -129,6 +125,10 @@
           {
             "type": "command",
             "command": "~/.claude/hooks/completion-claim-check.sh"
+          },
+          {
+            "type": "command",
+            "command": "~/.claude/hooks/failure-log.sh"
           }
         ]
       }

--- a/tests/test_hooks.sh
+++ b/tests/test_hooks.sh
@@ -426,6 +426,60 @@ run_output_test "stop_hook_active → 無出力" "$COMP" \
 "" "true"
 
 echo ""
+echo "=== failure-log.sh ==="
+echo ""
+
+FAILLOG="/workspace/hooks/failure-log.sh"
+
+# ログファイル内容を検証する (failure-log は stdout でなく auto-fail.log に書く)。
+# 各テストは独立した一時 CWD で実行し offset/ログの持ち越しを防ぐ。
+run_faillog_test() {
+    _desc="$1"; _jsonl="$2"; _expect="$3"; _absent="${4:-}"
+    TOTAL=$((TOTAL + 1))
+    _wd=$(mktemp -d); _tf="${_wd}/transcript.jsonl"
+    printf '%s\n' "$_jsonl" > "$_tf"
+    _pl=$(printf '{"hook_event_name":"Stop","transcript_path":"%s","cwd":"%s"}' "$_tf" "$_wd")
+    ( cd "$_wd" && printf '%s' "$_pl" | "$FAILLOG" >/dev/null 2>&1 )
+    _log="${_wd}/claude_tmp/failure_log/auto-fail.log"
+    _content=""; [ -f "$_log" ] && _content=$(cat "$_log")
+    _ok=1
+    if [ -n "$_expect" ]; then case "$_content" in *"$_expect"*) ;; *) _ok=0 ;; esac; fi
+    if [ -n "$_absent" ]; then case "$_content" in *"$_absent"*) _ok=0 ;; esac; fi
+    if [ "$_ok" -eq 1 ]; then printf "  PASS: %s\n" "$_desc"; PASS=$((PASS + 1));
+    else printf "  FAIL: %s (expect=%s absent=%s)\n" "$_desc" "$_expect" "$_absent"; FAIL=$((FAIL + 1)); fi
+    rm -rf "$_wd"
+}
+
+FAIL_JSONL='{"type":"assistant","message":{"content":[{"type":"tool_use","name":"Bash","id":"toolu_fail1","input":{"command":"ls /nonexistent"}}]}}
+{"type":"user","toolUseResult":"Error: Exit code 2\nls: cannot access","message":{"content":[{"type":"tool_result","is_error":true,"tool_use_id":"toolu_fail1"}]}}'
+
+OK_JSONL='{"type":"assistant","message":{"content":[{"type":"tool_use","name":"Bash","id":"toolu_ok","input":{"command":"echo hi"}}]}}
+{"type":"user","toolUseResult":"hi","message":{"content":[{"type":"tool_result","is_error":false,"tool_use_id":"toolu_ok"}]}}'
+
+SECRET_JSONL='{"type":"assistant","message":{"content":[{"type":"tool_use","name":"Bash","id":"toolu_sec","input":{"command":"deploy --token=abc123XYZ"}}]}}
+{"type":"user","toolUseResult":"Error: auth failed","message":{"content":[{"type":"tool_result","is_error":true,"tool_use_id":"toolu_sec"}]}}'
+
+echo "--- 失敗 Bash の記録 / 成功の除外 ---"
+run_faillog_test "失敗 Bash (is_error) を記録" "$FAIL_JSONL" "id: toolu_fail1" ""
+run_faillog_test "失敗コマンド本文を記録" "$FAIL_JSONL" "ls /nonexistent" ""
+run_faillog_test "成功 Bash は記録しない" "$OK_JSONL" "" "toolu_ok"
+
+echo "--- 秘密情報のマスク ---"
+run_faillog_test "token 値を <redacted> にマスク" "$SECRET_JSONL" "<redacted>" "abc123XYZ"
+
+echo "--- offset による重複防止 (2 回実行で 1 件) ---"
+TOTAL=$((TOTAL + 1))
+_wd=$(mktemp -d); _tf="${_wd}/t.jsonl"
+printf '%s\n' "$FAIL_JSONL" > "$_tf"
+_pl=$(printf '{"hook_event_name":"Stop","transcript_path":"%s","cwd":"%s"}' "$_tf" "$_wd")
+( cd "$_wd" && printf '%s' "$_pl" | "$FAILLOG" >/dev/null 2>&1 )
+( cd "$_wd" && printf '%s' "$_pl" | "$FAILLOG" >/dev/null 2>&1 )
+_cnt=$(grep -c '^id: ' "${_wd}/claude_tmp/failure_log/auto-fail.log" 2>/dev/null || echo 0)
+if [ "$_cnt" -eq 1 ]; then printf "  PASS: 2 回実行で 1 件 (offset dedup)\n"; PASS=$((PASS + 1));
+else printf "  FAIL: offset dedup (count=%s, expected 1)\n" "$_cnt"; FAIL=$((FAIL + 1)); fi
+rm -rf "$_wd"
+
+echo ""
 echo "=== 結果: ${PASS}/${TOTAL} passed, ${FAIL} failed ==="
 
 if [ "$FAIL" -gt 0 ]; then


### PR DESCRIPTION
`PostToolUse[Bash]` は Bash がエラー判定したコマンドで発火せず、`tool_response` に終了コードも無いため失敗コマンドが記録されなかった (2026-06-05実ペイロード実証)。
失敗は `transcript` の `is_error==true` にのみ残るため、**Stop フックで抽出する方式へ移行**する。

- transcript を offset(バイト位置) で増分読みし累積 `O(N)` に抑制
- 秘密情報 (token/key/bearer 類) を <redacted> にマスク
- realpath で TOCTOU 緩和、jq 失敗時は offset 据え置きで次ターン再試行
- settings.json: `failure-log.sh` を `PostToolUse[Bash]` → `Stop` へ移設
- tests/test_hooks.sh に `failure-log` 5 ケース追加
