### PR TITLE
fix: context-monitor の 1M window 誤判定を修正

### DIFF
--- a/claude/hooks/context-monitor.sh
+++ b/claude/hooks/context-monitor.sh
@@ -27,14 +27,29 @@ if [ -z "$JQ" ]; then
     exit 0
 fi
 
-HOOK_EVENT=$(printf '%s\n' "$INPUT" | "$JQ" -r '.hook_event_name // ""' 2>/dev/null) || HOOK_EVENT=""
-TRANSCRIPT_PATH=$(printf '%s\n' "$INPUT" | "$JQ" -r '.transcript_path // ""' 2>/dev/null) || TRANSCRIPT_PATH=""
-CWD=$(printf '%s\n' "$INPUT" | "$JQ" -r '.cwd // ""' 2>/dev/null) || CWD=""
+# 入力フィールドを 1 回の jq で取得 (高頻度 hook のため fork を最小化)
+# jq は値ごとに改行出力するため、空フィールドも空行として位置を保てる
+{
+    read -r HOOK_EVENT
+    read -r TRANSCRIPT_PATH
+    read -r CWD
+    read -r SESSION_ID
+} <<EOF
+$(printf '%s\n' "$INPUT" | "$JQ" -r '.hook_event_name // "", .transcript_path // "", .cwd // "", .session_id // ""' 2>/dev/null)
+EOF
+
+# パストラバーサル対策: session_id は外部 (Claude Code) 由来。
+# キャッシュファイル名に使うため、パス要素として安全な文字のみ許容する
+SESSION_ID=$(printf '%s' "$SESSION_ID" | tr -cd 'A-Za-z0-9_-')
+[ "${#SESSION_ID}" -gt 128 ] && SESSION_ID=""
 
 DEFAULT_CONTEXT_WINDOW_SIZE=200000
 USABLE_CONTEXT_RATIO_NUM=4
 USABLE_CONTEXT_RATIO_DEN=5
 PERCENT_SCALE=100
+WARN_THRESHOLD=50
+CRITICAL_THRESHOLD=75
+CACHE_MAX_AGE_SEC=90
 
 # context-model-getter.sh は同一 hooks ディレクトリに symlink される兄弟スクリプト
 SCRIPT_DIR=$(CDPATH= cd -- "$(dirname -- "$0")" 2>/dev/null && pwd) || SCRIPT_DIR=""
@@ -48,6 +63,10 @@ trim() {
     }'
 }
 
+# NOTE: PostToolUse / UserPromptSubmit hook の stdin には context_window も model も
+# 渡されない (公式仕様 https://code.claude.com/docs/en/hooks.md)。下記 2 関数は当該
+# イベントでは常に空文字を返すが、将来 API が hook へ model/context_window を渡す変更に
+# 備えて保持する。通常の使用率算出は statusline キャッシュ経由 (下記) が担う。
 hook_context_window_size() {
     # shellcheck disable=SC2016
     printf '%s\n' "$INPUT" | "$JQ" -r '
@@ -88,7 +107,7 @@ hook_model_identifier() {
 
 transcript_model_identifier() {
     # shellcheck disable=SC2016
-    tail -200 "$TRANSCRIPT_PATH" | "$JQ" -s -r '
+    tail -200 -- "$TRANSCRIPT_PATH" | "$JQ" -s -r '
         def model_text($m):
             if ($m | type) == "string" then $m
             elif ($m | type) == "object" then
@@ -148,6 +167,35 @@ resolve_model_limit() {
     printf '%s\n' "$((DEFAULT_CONTEXT_WINDOW_SIZE * USABLE_CONTEXT_RATIO_NUM / USABLE_CONTEXT_RATIO_DEN))"
 }
 
+# statusline wrapper が書いた権威あるキャッシュから "実効上限 使用トークン" を解決する。
+# 新鮮 (CACHE_MAX_AGE_SEC 以内) かつ context_window_size が有効な場合のみ 1 行出力する。
+# 出力なし (空) = キャッシュ無効 → 呼び出し側で resolve_model_limit にフォールバックさせる。
+resolve_from_cache() {
+    cache_file="${XDG_CACHE_HOME:-$HOME/.cache}/claude-context/context-${SESSION_ID}.json"
+    [ -n "$SESSION_ID" ] && [ -f "$cache_file" ] || return 0
+
+    # macOS の date は %s 非対応のケースあり。空なら新鮮さ判定をスキップ (安全側 = fallback)
+    now=$(date +%s 2>/dev/null || echo "")
+    mtime=$(stat -c %Y "$cache_file" 2>/dev/null || stat -f %m "$cache_file" 2>/dev/null || echo "")
+    [ -n "$now" ] && [ -n "$mtime" ] && [ "$((now - mtime))" -le "$CACHE_MAX_AGE_SEC" ] || return 0
+
+    # cache の 2 値を 1 回の jq で取得 (値ごと改行 → 空行で位置保持)
+    {
+        read -r cache_window
+        read -r cache_length
+    } <<EOF
+$("$JQ" -r '.context_window_size // "", .context_length // ""' "$cache_file" 2>/dev/null)
+EOF
+    [ -n "$cache_window" ] && [ "$cache_window" -gt 0 ] 2>/dev/null || return 0
+
+    usable=$((cache_window * USABLE_CONTEXT_RATIO_NUM / USABLE_CONTEXT_RATIO_DEN))
+    if [ -n "$cache_length" ] && [ "$cache_length" -gt 0 ] 2>/dev/null; then
+        printf '%s %s\n' "$usable" "$cache_length"
+    else
+        printf '%s %s\n' "$usable" "$USAGE_LINE"
+    fi
+}
+
 # transcript がなければスキップ
 if [ -z "$TRANSCRIPT_PATH" ] || [ ! -f "$TRANSCRIPT_PATH" ]; then
     exit 0
@@ -158,14 +206,14 @@ fi
 # timestamp 最大 (ISO 文字列の辞書順 = 時系列順) の usage を jq で抽出
 # jq変数 $latest をシェル展開させないため単一引用符で囲む (二重引用符だと空展開で常に0になる)
 # shellcheck disable=SC2016
-USAGE_LINE=$(tail -200 "$TRANSCRIPT_PATH" | "$JQ" -s -r '
+USAGE_LINE=$(tail -200 -- "$TRANSCRIPT_PATH" | "$JQ" -s -r '
     [ .[]
         | select((.isSidechain // false) == false)
         | select((.isApiErrorMessage // false) == false)
         | select(.message.usage != null) ]
         | (max_by(.timestamp // "") // null) as $latest
         | if $latest == null then 0
-      else (($latest.message.usage.input_tokens // 0) + ($latest.message.usage.cache_read_input_tokens // 0))
+      else (($latest.message.usage.input_tokens // 0) + ($latest.message.usage.cache_read_input_tokens // 0) + ($latest.message.usage.cache_creation_input_tokens // 0))
     end
 ' 2>/dev/null || echo "0")
 
@@ -173,16 +221,26 @@ if [ "$USAGE_LINE" -eq 0 ] 2>/dev/null; then
     exit 0
 fi
 
-# 分母は full window ではなく auto-compact が効く実効上限 (usableTokens)
-USABLE_LIMIT=$(resolve_model_limit)
+# --- 分母 (window) と分子 (使用トークン) の決定 ---
+# 優先: statusline wrapper が書いた権威あるキャッシュ (真の context_window_size)。
+# hook stdin には context_window/model が来ない (公式仕様) ため、これが唯一の正確な源。
+# フォールバック: model id 推定 (resolve_model_limit) + transcript 由来の使用トークン。
+cache_resolved=$(resolve_from_cache)
+if [ -n "$cache_resolved" ]; then
+    USABLE_LIMIT=${cache_resolved% *}
+    USED_TOKENS=${cache_resolved#* }
+else
+    USABLE_LIMIT=$(resolve_model_limit)
+    USED_TOKENS="$USAGE_LINE"
+fi
 
-# 使用率算出 (整数パーセント)
-USAGE_PCT=$((USAGE_LINE * PERCENT_SCALE / USABLE_LIMIT))
+# 使用率算出 (整数パーセント、100% でキャップ = ccstatusline 準拠)
+USAGE_PCT=$((USED_TOKENS * PERCENT_SCALE / USABLE_LIMIT))
+if [ "$USAGE_PCT" -gt "$PERCENT_SCALE" ]; then
+    USAGE_PCT="$PERCENT_SCALE"
+fi
 
 # --- 閾値判定 ---
-WARN_THRESHOLD=50
-CRITICAL_THRESHOLD=75
-
 if [ "$USAGE_PCT" -lt "$WARN_THRESHOLD" ]; then
     # 安全圏: 何もしない
     exit 0
@@ -205,16 +263,13 @@ case "$HOOK_EVENT" in
         echo "$MSG"
         ;;
     PostToolUse|PostToolUseFailure)
-        # PostToolUse hook: JSON で additionalContext
-        ESCAPED_MSG=$(printf '%s' "$MSG" | sed 's/\\/\\\\/g' | sed 's/"/\\"/g')
-        cat <<EOF
-{
-    "hookSpecificOutput": {
-        "hookEventName": "PostToolUse",
-        "additionalContext": "${ESCAPED_MSG}"
-    }
-}
-EOF
+        # PostToolUse hook: JSON で additionalContext (jq でエスケープを確実化)
+        printf '%s' "$MSG" | "$JQ" -Rs '{
+            hookSpecificOutput: {
+                hookEventName: "PostToolUse",
+                additionalContext: .
+            }
+        }'
         ;;
     *)
         # 未知の呼び出し元: stderr に出力(verbose mode)

--- a/claude/hooks/statusline-context-cache.sh
+++ b/claude/hooks/statusline-context-cache.sh
@@ -1,0 +1,59 @@
+#!/bin/sh
+# statusline-context-cache.sh - statusLine payload の context_window をキャッシュ
+#
+# 責務:
+#   - statusLine の rich payload (context_window / model を含む) を受け取り、
+#     権威ある context window size / 使用量をキャッシュファイルへ書く
+#   - 表示は ccstatusline にパススルーする
+#
+# 背景:
+#   context-monitor.sh は hook のため、公式仕様上 stdin に context_window も model も
+#   渡されない (https://code.claude.com/docs/en/hooks.md)。これらを受け取れるのは
+#   statusLine のみ。本 wrapper が橋渡しし、hook がキャッシュ経由で真の window を読む。
+#
+# 有効化:
+#   settings.json の statusLine.command を本スクリプトに向けること。
+#   直接 ccstatusline を指している場合はキャッシュが書かれない。
+#
+# 出力: stdin をそのまま ccstatusline へ渡した結果 (statusline 表示)
+
+# stdin が無ければそのまま ccstatusline へ委譲
+if [ -t 0 ]; then
+    exec bunx -y ccstatusline@latest
+fi
+
+INPUT=$(cat)
+
+# --- キャッシュ書き込み (失敗は無視 = 表示を壊さない) ---
+# jaq 優先、jq フォールバック
+JQ=$(command -v jaq 2>/dev/null || command -v jq 2>/dev/null || echo "")
+if [ -n "$JQ" ] && [ -n "$HOME" ]; then
+    SESSION_ID=$(printf '%s' "$INPUT" | "$JQ" -r '.session_id // ""' 2>/dev/null) || SESSION_ID=""
+    # パストラバーサル対策: session_id は外部由来。パス要素として安全な文字のみ許容
+    SESSION_ID=$(printf '%s' "$SESSION_ID" | tr -cd 'A-Za-z0-9_-')
+    [ "${#SESSION_ID}" -gt 128 ] && SESSION_ID=""
+    if [ -n "$SESSION_ID" ]; then
+        CACHE_DIR="${XDG_CACHE_HOME:-$HOME/.cache}/claude-context"
+        if mkdir -p "$CACHE_DIR" 2>/dev/null; then
+            # context_length = current_usage を context window 占有トークンへ正規化
+            # (object 形式は input + cache_creation + cache_read、number 形式はそのまま)
+            # shellcheck disable=SC2016
+            printf '%s' "$INPUT" | "$JQ" -c '
+                (.context_window.current_usage) as $u
+                | {
+                    session_id: (.session_id // ""),
+                    context_window_size: (.context_window.context_window_size // null),
+                    used_percentage: (.context_window.used_percentage // null),
+                    context_length: (
+                        if ($u | type) == "object" then
+                            (($u.input_tokens // 0) + ($u.cache_creation_input_tokens // 0) + ($u.cache_read_input_tokens // 0))
+                        elif ($u | type) == "number" then $u
+                        else null end
+                    )
+                }' > "$CACHE_DIR/context-${SESSION_ID}.json" 2>/dev/null || true
+        fi
+    fi
+fi
+
+# 表示は必ず ccstatusline へパススルー (キャッシュ書き込みの成否に関わらず)
+printf '%s' "$INPUT" | bunx -y ccstatusline@latest

--- a/claude/settings.json
+++ b/claude/settings.json
@@ -188,7 +188,7 @@
   },
   "statusLine": {
     "type": "command",
-    "command": "bunx -y ccstatusline@latest",
+    "command": "$HOME/.claude/hooks/statusline-context-cache.sh",
     "padding": 0,
     "refreshInterval": 10
   },

--- a/tests/test_hooks.sh
+++ b/tests/test_hooks.sh
@@ -380,6 +380,60 @@ run_context_monitor_test "hook context_window.max_tokens 128k → usable 102.4k 
 run_context_monitor_test "transcript message.model 100k → usable 80k 分母で 75%" '{}' '{"display_name":"Claude Test (100k)"}' "[Context 75%]"
 run_context_monitor_test "モデル不明時は 200k の usable 160k 分母 (37% で警告なし)" '{}' "" ""
 
+# --- statusline キャッシュ経路 (権威ある context_window) ---
+# cache を XDG_CACHE_HOME 配下に置き session_id で参照させる。transcript usage=60000 は
+# cache hit 時は context_length で上書きされるため fallback 判定にのみ影響する。
+run_cache_test() {
+    _desc="$1"; _sid="$2"; _cw="$3"; _cl="$4"; _age="$5"; _expect="$6"
+    TOTAL=$((TOTAL + 1))
+    _wd=$(mktemp -d); _tf="${_wd}/transcript.jsonl"; _cache="${_wd}/cache"
+    mkdir -p "${_cache}/claude-context"
+    jq -n '{timestamp:"2026-01-01T00:00:00Z", isSidechain:false, message:{usage:{input_tokens:60000, cache_read_input_tokens:0}}}' > "$_tf"
+    jq -n --arg sid "$_sid" --argjson cw "$_cw" --argjson cl "$_cl" \
+        '{session_id:$sid, context_window_size:$cw, context_length:$cl}' > "${_cache}/claude-context/context-${_sid}.json"
+    [ "$_age" = "stale" ] && touch -t 202001010000 "${_cache}/claude-context/context-${_sid}.json"
+    _input=$(jq -n --arg path "$_tf" --arg cwd "$_wd" --arg sid "$_sid" \
+        '{hook_event_name:"UserPromptSubmit", transcript_path:$path, cwd:$cwd, session_id:$sid}')
+    _out=$(printf '%s' "$_input" | XDG_CACHE_HOME="$_cache" "$CONTEXT_MONITOR" 2>/dev/null)
+    rm -rf "$_wd"
+    if [ -z "$_expect" ]; then
+        if [ -z "$_out" ]; then printf "  PASS: %s\n" "$_desc"; PASS=$((PASS + 1))
+        else printf "  FAIL: %s (expected empty, got: %s)\n" "$_desc" "$_out"; FAIL=$((FAIL + 1)); fi
+    else
+        case "$_out" in
+            *"$_expect"*) printf "  PASS: %s\n" "$_desc"; PASS=$((PASS + 1)) ;;
+            *) printf "  FAIL: %s (missing substr: %s)\n" "$_desc" "$_expect"; FAIL=$((FAIL + 1)) ;;
+        esac
+    fi
+}
+
+# 新鮮な 1M cache: 214344/800000=26% → WARN 50 未満で無出力 (本修正の核心: 誤 131% 解消)
+run_cache_test "fresh 1M cache 26% → 警告なし" "s1m26" 1000000 214344 fresh ""
+# 新鮮な 1M cache: 700000/800000=87% → critical
+run_cache_test "fresh 1M cache 87% → critical" "s1m87" 1000000 700000 fresh "[Context 87%]"
+# 100% cap: 200k cache 180000/160000=112% → 100% にキャップ
+run_cache_test "200k cache 112% → 100% cap" "s200" 200000 180000 fresh "[Context 100%]"
+# 古い cache は無視 → fallback (transcript 60000 / 200k usable 160k = 37% で無出力)。
+# cache が使われれば 60000/40000=100% critical になるはずなので、無出力 = 古さ判定が効いている証拠
+run_cache_test "stale cache は無視され fallback (警告なし)" "sstale" 50000 60000 stale ""
+
+# パストラバーサル対策: 悪意 session_id はサニタイズされ planted cache に一致しない → fallback
+TOTAL=$((TOTAL + 1))
+_pt_wd=$(mktemp -d); _pt_tf="${_pt_wd}/transcript.jsonl"; _pt_cache="${_pt_wd}/cache"
+mkdir -p "${_pt_cache}/claude-context"
+jq -n '{timestamp:"2026-01-01T00:00:00Z", isSidechain:false, message:{usage:{input_tokens:60000, cache_read_input_tokens:0}}}' > "$_pt_tf"
+_pt_input=$(jq -n --arg path "$_pt_tf" --arg cwd "$_pt_wd" \
+    '{hook_event_name:"UserPromptSubmit", transcript_path:$path, cwd:$cwd, session_id:"../../../../tmp/pwned"}')
+# サニタイズ後の session_id では planted cache に一致せず fallback (37% で無出力) になる。
+# 出力が空 = 悪意パスでファイル参照していない証拠
+_pt_out=$(printf '%s' "$_pt_input" | XDG_CACHE_HOME="$_pt_cache" "$CONTEXT_MONITOR" 2>/dev/null)
+if [ -z "$_pt_out" ]; then
+    printf "  PASS: %s\n" "悪意 session_id (パストラバーサル) はサニタイズされ fallback"; PASS=$((PASS + 1))
+else
+    printf "  FAIL: %s (out: %s)\n" "悪意 session_id サニタイズ" "$_pt_out"; FAIL=$((FAIL + 1))
+fi
+rm -rf "$_pt_wd"
+
 echo ""
 # ============================================================
 # Stop hooks: sycophancy-check.sh / completion-claim-check.sh


### PR DESCRIPTION
- hook は公式仕様上 stdin に context_window/model を受け取れず 200k 既定へフォールバックするため、1M セッションで使用率が 131% 等になり誤った critical警告を出していた
- statusLine payload の context_window をキャッシュし hook が読む機構を追加して算出を正確化する。使用率は 100% でキャップ、分子にcache_creation を加算、session_id はパストラバーサル対策でサニタイズする
- statusLine を wrapper 経由に配線 (ccstatusline は同一コマンドで呼ぶためカスタムデザインは保持される)
