### PR TITLE
fix(shell): defer aliases until runtime PATH is ready

### DIFF
--- a/config/shell/aliases.sh
+++ b/config/shell/aliases.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 # shell/aliases.sh - 共通エイリアス (POSIX互換)
 #
-# 読み込み元: common.sh
+# 読み込み元: common.sh、またはランタイム初期化後のbashrc/zshrc
 # 注意: シェル固有のエイリアスは各シェルの設定ファイルに記述
 
 # SC1091: 外部 aliases.local の source は追跡不可を許容

--- a/config/shell/bash/bashrc
+++ b/config/shell/bash/bashrc
@@ -87,6 +87,9 @@ fi
 # ============================================================================
 
 # 共通設定を読み込み
+# common.sh が source 中に参照するため、ShellCheck のファイル単位解析からは未使用に見える
+# shellcheck disable=SC2034
+DOTFILES_DEFER_ALIASES=1
 if [[ -f "$HOME/.shell_common" ]]; then
     source "$HOME/.shell_common"
 elif [[ -f "$DOTFILES_DIR/config/shell/common.sh" ]]; then
@@ -114,6 +117,15 @@ if command -v mise >/dev/null 2>&1; then
     __bashrc_eval_output mise activate bash
     shopt -s checkhash 2>/dev/null || true
 fi
+
+# ============================================================================
+# エイリアス
+# ============================================================================
+
+if [[ -f "$DOTFILES_DIR/config/shell/aliases.sh" ]]; then
+    source "$DOTFILES_DIR/config/shell/aliases.sh"
+fi
+unset DOTFILES_DEFER_ALIASES
 
 # ============================================================================
 # bash オプション

--- a/config/shell/common.sh
+++ b/config/shell/common.sh
@@ -248,7 +248,8 @@ _dotfiles_load_platform
 # エイリアス読み込み
 # ============================================================================
 
-if [ -f "$DOTFILES_DIR/config/shell/aliases.sh" ]; then
+if [ -z "${DOTFILES_DEFER_ALIASES:-}" ] &&
+    [ -f "$DOTFILES_DIR/config/shell/aliases.sh" ]; then
     . "$DOTFILES_DIR/config/shell/aliases.sh"
 fi
 

--- a/config/shell/zsh/zshrc
+++ b/config/shell/zsh/zshrc
@@ -27,6 +27,7 @@ export GIT_SSH_COMMAND="ssh"
 
 # 共通設定を読み込み
 # ~/.shell_common があれば優先 (install.sh --shell-common でインストール)
+DOTFILES_DEFER_ALIASES=1
 if [[ -f "$HOME/.shell_common" ]]; then
     source "$HOME/.shell_common"
 elif [[ -f "$DOTFILES_DIR/config/shell/common.sh" ]]; then
@@ -49,6 +50,15 @@ if command -v mise &>/dev/null; then
 elif [[ -x "$HOME/.local/bin/mise" ]]; then
     eval "$("${HOME}/.local/bin/mise" activate zsh)"
 fi
+
+# ============================================================================
+# エイリアス
+# ============================================================================
+
+if [[ -f "$DOTFILES_DIR/config/shell/aliases.sh" ]]; then
+    source "$DOTFILES_DIR/config/shell/aliases.sh"
+fi
+unset DOTFILES_DEFER_ALIASES
 
 # ============================================================================
 # zsh オプション

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -14,6 +14,7 @@ import tomllib
 from pathlib import Path
 
 INSTALL_SH = Path(__file__).resolve().parent.parent / "install.sh"
+BASHRC = INSTALL_SH.parent / "config" / "shell" / "bash" / "bashrc"
 REPO_ROOT = INSTALL_SH.parent
 STOW_INSTALL_SH = REPO_ROOT / "scripts" / "stow-install.sh"
 MODEL_PROFILE_PATHS = (
@@ -21,6 +22,75 @@ MODEL_PROFILE_PATHS = (
     "codex/fast.config.toml",
     "codex/deep-review.config.toml",
 )
+
+
+def _write_executable(path: Path, content: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8")
+    path.chmod(0o755)
+
+
+def _create_fake_mise_shell_runtime(tmp_path: Path) -> tuple[Path, Path, Path]:
+    home = tmp_path / "home"
+    fake_bin = home / ".local" / "bin"
+    eza_bin = tmp_path / "mise-eza-bin"
+
+    _write_executable(
+        fake_bin / "mise",
+        "#!/bin/sh\n"
+        'if [ "$1" = activate ] && [ "$2" = bash ]; then\n'
+        "    printf 'export PATH=\"%s:$PATH\"\\n' "
+        '"$FAKE_MISE_EZA_BIN"\n'
+        "fi\n",
+    )
+    _write_executable(
+        fake_bin / "ssh-agent",
+        "#!/bin/sh\n"
+        "printf '%s\\n' "
+        "'SSH_AUTH_SOCK=/tmp/fake-agent.sock; export SSH_AUTH_SOCK;' "
+        "'SSH_AGENT_PID=1; export SSH_AGENT_PID;'\n",
+    )
+    _write_executable(fake_bin / "ssh-add", "#!/bin/sh\nexit 0\n")
+    _write_executable(eza_bin / "eza", "#!/bin/sh\nexit 0\n")
+    return home, fake_bin, eza_bin
+
+
+def _run_bashrc(
+    home: Path, fake_bin: Path, eza_bin: Path
+) -> subprocess.CompletedProcess[str]:
+    env = {
+        "DOTFILES_DIR": str(REPO_ROOT),
+        "FAKE_MISE_EZA_BIN": str(eza_bin),
+        "HOME": str(home),
+        "PATH": f"{fake_bin}:/usr/bin:/bin",
+        "TERM": "xterm-256color",
+        "USER": "test",
+    }
+    return subprocess.run(
+        [
+            "/bin/bash",
+            "--noprofile",
+            "--norc",
+            "-ic",
+            f'source "{BASHRC}"; alias lla',
+        ],
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=10,
+    )
+
+
+class TestShellInitialization:
+    def test_bash_selects_mise_eza_on_first_start(self, tmp_path: Path) -> None:
+        home, fake_bin, eza_bin = _create_fake_mise_shell_runtime(tmp_path)
+        result = _run_bashrc(home, fake_bin, eza_bin)
+
+        assert result.returncode == 0, result.stderr
+        assert (
+            "alias lla='eza -la --git --group-directories-first --sort=name'"
+            in result.stdout
+        )
 
 
 def _run_install_sh(


### PR DESCRIPTION
fix(shell): defer aliases until runtime PATH is ready

- load shared aliases after Homebrew and mise initialization
- preserve direct common.sh alias loading for compatibility
- cover first-start eza selection with a regression test