### PR TITLE
chore: rtk トークン圧縮ラッパーを撤去

### DIFF
--- a/claude/hooks/local-command-block.sh
+++ b/claude/hooks/local-command-block.sh
@@ -131,50 +131,6 @@ get_first_command() {
     }'
 }
 
-# --- RTK wrapper の内側コマンドを検査対象に正規化 ---
-normalize_rtk_segment() {
-    printf '%s' "$1" | awk '
-        function base_name(value, parts, count) {
-            count = split(value, parts, "/")
-            return parts[count]
-        }
-        {
-            start = 0
-            for (i=1; i<=NF; i++) {
-                if ($i ~ /^[A-Za-z_][A-Za-z0-9_]*=/) continue
-                if ($i == "env") {
-                    i++
-                    while (i<=NF) {
-                        if ($i ~ /^-.*[uSC]$/) { i += 2; continue }
-                        if ($i ~ /^-/) { i++; continue }
-                        if ($i ~ /^[A-Za-z_][A-Za-z0-9_]*=/) { i++; continue }
-                        break
-                    }
-                    if (i>NF) { print $0; exit }
-                }
-                start = i
-                break
-            }
-            if (start == 0) { print $0; exit }
-            if (base_name($start) != "rtk") { print $0; exit }
-
-            next_index = start + 1
-            if (next_index > NF) { print ""; exit }
-            if ($next_index ~ /^(--version|-V|version|gain|discover|hook)$/) { print ""; exit }
-            if ($next_index == "proxy") {
-                next_index++
-                if (next_index > NF) { print ""; exit }
-            }
-
-            out = ""
-            for (i=next_index; i<=NF; i++) {
-                out = out (out ? " " : "") $i
-            }
-            print out
-            exit
-        }'
-}
-
 # --- クォート対応のセグメント分割 ---
 # シェル演算子 (&& || ; |) で分割するが、引用符 ('...' "...") 内の演算子は区切らない。
 # これによりクォート内文字列 (grep パターン "a|b|c" 等) の | が誤って分割され、
@@ -224,7 +180,7 @@ is_version_probe() {
 
 # --- 個別セグメントのブロックチェック関数 ---
 check_segment() {
-    _seg=$(normalize_rtk_segment "$1")
+    _seg="$1"
     [ -z "$_seg" ] && return 0
     if is_docker_command "$_seg"; then
         return 0
@@ -259,7 +215,6 @@ check_raw_input_fallback() {
 '
     for _fseg in $_fallback_segs; do
         _fseg=$(printf '%s' "$_fseg" | sed 's/^[[:space:]]*//; s/[[:space:]]*$//')
-        _fseg=$(normalize_rtk_segment "$_fseg")
         is_version_probe "$_fseg" && continue
         _fcmd=$(get_first_command "$_fseg")
         if [ -n "$_fcmd" ] && printf '%s\n' "$_fcmd" | grep -qE "$BLOCKED_EXACT" 2>/dev/null; then

--- a/claude/settings.json
+++ b/claude/settings.json
@@ -67,15 +67,6 @@
             "command": "$HOME/.claude/hooks/main-branch-code-warning.sh"
           }
         ]
-      },
-      {
-        "matcher": "Bash",
-        "hooks": [
-          {
-            "type": "command",
-            "command": "rtk hook claude"
-          }
-        ]
       }
     ],
     "PostToolUse": [

--- a/codex/global_AGENTS.md
+++ b/codex/global_AGENTS.md
@@ -57,12 +57,6 @@ Skill routing:
 - `rules-enforce.sh` scans changed code after edits and at turn stop; if it reports `BLOCK`, fix the violations before final output.
 - For semantic rules that cannot be fully scanned, use `$rules-compliance-review`; for large/high-risk diffs, dispatch one rules-only review subagent and then parent session makes the final decision.
 
-## RTK
-
-- `rtk` が利用可能な環境では、Bash コマンドは原則 `rtk <command>` で実行して出力を圧縮する。
-- `rtk gain`, `rtk gain --history`, `rtk proxy <command>` は必要時のみ使う。
-- safety hooks は `rtk` wrapper の内側コマンドを検査する。禁止されるローカル実行や破壊的操作を `rtk` で迂回しない。
-
 ## WebFetch fallback
 
 - If built-in WebFetch fails or returns incomplete/noisy content, use `r.jina.ai` first for public URLs.

--- a/codex/hooks/local-command-block.sh
+++ b/codex/hooks/local-command-block.sh
@@ -124,53 +124,9 @@ get_first_command() {
     }'
 }
 
-# --- RTK wrapper の内側コマンドを検査対象に正規化 ---
-normalize_rtk_segment() {
-    printf '%s' "$1" | awk '
-        function base_name(value, parts, count) {
-            count = split(value, parts, "/")
-            return parts[count]
-        }
-        {
-            start = 0
-            for (i=1; i<=NF; i++) {
-                if ($i ~ /^[A-Za-z_][A-Za-z0-9_]*=/) continue
-                if ($i == "env") {
-                    i++
-                    while (i<=NF) {
-                        if ($i ~ /^-.*[uSC]$/) { i += 2; continue }
-                        if ($i ~ /^-/) { i++; continue }
-                        if ($i ~ /^[A-Za-z_][A-Za-z0-9_]*=/) { i++; continue }
-                        break
-                    }
-                    if (i>NF) { print $0; exit }
-                }
-                start = i
-                break
-            }
-            if (start == 0) { print $0; exit }
-            if (base_name($start) != "rtk") { print $0; exit }
-
-            next_index = start + 1
-            if (next_index > NF) { print ""; exit }
-            if ($next_index ~ /^(--version|-V|version|gain|discover|hook)$/) { print ""; exit }
-            if ($next_index == "proxy") {
-                next_index++
-                if (next_index > NF) { print ""; exit }
-            }
-
-            out = ""
-            for (i=next_index; i<=NF; i++) {
-                out = out (out ? " " : "") $i
-            }
-            print out
-            exit
-        }'
-}
-
 # --- 個別セグメントのブロックチェック関数 ---
 check_segment() {
-    _seg=$(normalize_rtk_segment "$1")
+    _seg="$1"
     [ -z "$_seg" ] && return 0
     if is_docker_command "$_seg"; then
         return 0
@@ -199,7 +155,6 @@ check_raw_input_fallback() {
 '
     for _fseg in $_fallback_segs; do
         _fseg=$(printf '%s' "$_fseg" | sed 's/^[[:space:]]*//; s/[[:space:]]*$//')
-        _fseg=$(normalize_rtk_segment "$_fseg")
         _fcmd=$(get_first_command "$_fseg")
         if [ -n "$_fcmd" ] && printf '%s\n' "$_fcmd" | grep -qE "$BLOCKED_EXACT" 2>/dev/null; then
             IFS="$_oldifs"

--- a/tests/test_codex_hooks.sh
+++ b/tests/test_codex_hooks.sh
@@ -234,11 +234,6 @@ DISPATCHER="${HOOK_DIR}/hook-dispatcher.sh"
 export CODEX_HOOK_TEST_MODE=1
 run_hook_test "$DISPATCHER pre-tool-use" "dispatcher allows runner build command" "$(make_input Bash command "npm run build")" 0
 run_hook_test "$DISPATCHER pre-tool-use" "dispatcher blocks package install command" "$(make_input Bash command "npm install")" 2
-run_hook_test "$DISPATCHER pre-tool-use" "dispatcher blocks rtk git commit command" "$(make_input Bash command "rtk git commit -m test")" 2
-run_hook_test "$DISPATCHER pre-tool-use" "dispatcher allows rtk runner build command" "$(make_input Bash command "rtk npm run build")" 0
-run_hook_test "$DISPATCHER pre-tool-use" "dispatcher blocks rtk package install command" "$(make_input Bash command "rtk npm install")" 2
-run_hook_test "$DISPATCHER pre-tool-use" "dispatcher blocks rtk runtime command" "$(make_input Bash command "rtk python3 script.py")" 2
-run_hook_test "$DISPATCHER pre-tool-use" "dispatcher blocks rtk proxy runtime command" "$(make_input Bash command "rtk proxy python3 script.py")" 2
 run_hook_stdout_empty_test "$DISPATCHER user-prompt-submit" "dispatcher suppresses prompt reminder output" "$(make_prompt_input "修正して")" 0
 run_rules_checksum_stability_test
 run_codex_rules_refresh_test

--- a/tests/test_hooks.sh
+++ b/tests/test_hooks.sh
@@ -42,7 +42,6 @@ echo "--- ブロックすべきコマンド (exit 2) ---"
 
 # git commit
 run_test "git commit -m test" "$(make_input 'git commit -m test')" 2
-run_test "rtk git commit -m test" "$(make_input 'rtk git commit -m test')" 2
 run_test "git commit --amend" "$(make_input 'git commit --amend')" 2
 run_test "git commit (引数なし)" "$(make_input 'git commit')" 2
 
@@ -178,12 +177,9 @@ run_local_test "php -r echo" "$(make_input 'php -r \"echo 1;\"')" 2
 run_local_test "perl -e print" "$(make_input 'perl -e \"print 1\"')" 2
 run_local_test "rustc main.rs" "$(make_input 'rustc main.rs')" 2
 run_local_test "bare: go" "$(make_input 'go')" 2
-run_local_test "rtk python3 script.py" "$(make_input 'rtk python3 script.py')" 2
-run_local_test "rtk proxy python3 script.py" "$(make_input 'rtk proxy python3 script.py')" 2
 
 # インストール/パッケージ追加系 (プロジェクト外汚染リスクあるため継続ブロック)
 run_local_test "npm install" "$(make_input 'npm install')" 2
-run_local_test "rtk npm install" "$(make_input 'rtk npm install')" 2
 run_local_test "pip install flask" "$(make_input 'pip install flask')" 2
 run_local_test "yarn add express" "$(make_input 'yarn add express')" 2
 run_local_test "poetry install" "$(make_input 'poetry install')" 2
@@ -303,9 +299,6 @@ run_local_test "cd && npm run dev" "$(make_input 'cd /app && npm run dev')" 0
 run_local_test "./gradlew build" "$(make_input './gradlew build')" 0
 run_local_test "/usr/bin/npm run" "$(make_input '/usr/bin/npm run dev')" 0
 run_local_test "FOO=bar npm test" "$(make_input 'FOO=bar npm test')" 0
-run_local_test "rtk npm run build" "$(make_input 'rtk npm run build')" 0
-run_local_test "rtk git diff" "$(make_input 'rtk git diff')" 0
-run_local_test "rtk gain" "$(make_input 'rtk gain')" 0
 
 # サブシェル内の安全なコマンド
 # shellcheck disable=SC2016


### PR DESCRIPTION
rtk を使わなくなったため、`settings.json` の hook 登録・AGENTS.md のガイダンス・テストケースを削除する
hook 側の `normalize_rtk_segment` は rtk 経由コマンドの内側を検査対象へ戻す正規化だったが、rtk が環境から消えれば到達しない分岐になるため残さない
