### PR TITLE
fix: pin Claude statusline dependency

### DIFF
--- a/claude/settings.json
+++ b/claude/settings.json
@@ -165,12 +165,6 @@
       }
     ]
   },
-  "statusLine": {
-    "type": "command",
-    "command": "bunx -y ccstatusline@latest",
-    "padding": 0,
-    "refreshInterval": 10
-  },
   "extraKnownMarketplaces": {
     "claude-plugins-official": {
       "source": {

--- a/claude/settings.json
+++ b/claude/settings.json
@@ -165,6 +165,12 @@
       }
     ]
   },
+  "statusLine": {
+    "type": "command",
+    "command": "bunx -y ccstatusline@2.2.27",
+    "padding": 0,
+    "refreshInterval": 10
+  },
   "extraKnownMarketplaces": {
     "claude-plugins-official": {
       "source": {


### PR DESCRIPTION
## 目的

#421 のP2として、Claude Code用`ccstatusline`は維持しつつ、10秒周期のruntime経路に残っていた`@latest`追従だけを解消する。

## 調査結果

`ccstatusline`はClaude Codeのcommand-backed status line向けに、model、git branch、token/context usage等を表示するMITのnpm package。公式README/Windows guideでは`bunx -y ccstatusline@latest`はquick start用で、固定version運用も案内されている。

Codex CLIにはClaude Codeの`statusLine.command`相当の外部command hookはまだない。一方、現行Codexは`[tui].status_line`のbuilt-in itemとしてmodel/reasoning、current dir、git branch、context、5h/weekly limit等を表示できる。本repoの`codex/config.toml.template`は既にこれらを設定済みのため、外部`codex-statusline`を追加すると責務が重複する。

## 変更

- `claude/settings.json`のstatus lineを復元
- `bunx -y ccstatusline@latest`から`bunx -y ccstatusline@2.2.27`へ固定
- status line機能自体は削除しない

## Codex方針

- native `[tui].status_line`を継続利用
- communityの`codex-statusline`実装は存在するが、現行Codex TUIへ任意の外部描画を差し込めないため導入しない
- OpenAI側のcustom status-line plugin hookが提供された時点で再評価する

## Issue

Part of #421

## 残作業

- `install.sh`に残る`~/.codex/prompts`の作成・cleanup・説明導線を削除する
- 上記まで完了後に #421 をCloseする

Draftのまま維持する。