### PR TITLE
ci: automate ccstatusline update PRs

### DIFF
--- a/.github/workflows/update-ccstatusline.yml
+++ b/.github/workflows/update-ccstatusline.yml
@@ -1,0 +1,90 @@
+name: update-ccstatusline
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "17 3 * * 1"
+
+permissions:
+  contents: write
+  pull-requests: write
+
+concurrency:
+  group: update-ccstatusline
+  cancel-in-progress: false
+
+jobs:
+  update:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        # actions/checkout v5, pinned to the same audited commit as verify.yml.
+        uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09
+        with:
+          fetch-depth: 0
+
+      - name: Resolve current and latest versions
+        id: versions
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          current=$(python3 - <<'PY'
+          import json
+          import re
+
+          with open("claude/settings.json", encoding="utf-8") as fh:
+              command = json.load(fh)["statusLine"]["command"]
+
+          match = re.fullmatch(r"bunx -y ccstatusline@(\d+\.\d+\.\d+)", command)
+          if not match:
+              raise SystemExit(f"unexpected ccstatusline command: {command!r}")
+
+          print(match.group(1))
+          PY
+          )
+          latest=$(npm view ccstatusline version)
+
+          printf 'current=%s\n' "$current" >> "$GITHUB_OUTPUT"
+          printf 'latest=%s\n' "$latest" >> "$GITHUB_OUTPUT"
+
+      - name: Update pinned version
+        if: steps.versions.outputs.current != steps.versions.outputs.latest
+        env:
+          VERSION: ${{ steps.versions.outputs.latest }}
+        run: |
+          python3 - <<'PY'
+          import json
+          import os
+          from pathlib import Path
+
+          path = Path("claude/settings.json")
+          data = json.loads(path.read_text(encoding="utf-8"))
+          data["statusLine"]["command"] = f"bunx -y ccstatusline@{os.environ['VERSION']}"
+          path.write_text(json.dumps(data, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+          PY
+
+      - name: Open or update dependency PR
+        if: steps.versions.outputs.current != steps.versions.outputs.latest
+        env:
+          GH_TOKEN: ${{ github.token }}
+          VERSION: ${{ steps.versions.outputs.latest }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          branch="deps/ccstatusline-${VERSION}"
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git checkout -B "$branch"
+          git add -- claude/settings.json
+          git commit -m "chore(deps): update ccstatusline to ${VERSION}"
+          git push --force-with-lease origin "HEAD:${branch}"
+
+          if [ "$(gh pr list --head "$branch" --state open --json number --jq 'length')" -eq 0 ]; then
+            gh pr create \
+              --base main \
+              --head "$branch" \
+              --title "chore(deps): update ccstatusline to ${VERSION}" \
+              --body "Automated weekly ccstatusline update.\n\n- Previous: ${{ steps.versions.outputs.current }}\n- New: ${VERSION}\n\nThe version remains pinned. Normal repository CI must pass before merge."
+          fi


### PR DESCRIPTION
## 目的

`ccstatusline`を固定versionで安全に使いながら、更新忘れを防ぐ。

## 方針

- runtimeでは引き続きexact versionを使用
- 毎週月曜と手動実行でnpmのlatestを確認
- 更新がある場合だけ`claude/settings.json`のpinを更新するdependency PRを作成
- versionは自動mergeせず、通常CIを通してから人間がmerge

CI自身がmainのversionを暗黙更新するのではなく、更新候補をPRとして可視化する。

## 変更

- `.github/workflows/update-ccstatusline.yml`を追加
- `claude/settings.json`のcommand形式が期待形から外れた場合はfail-fast
- `actions/checkout`は既存`verify.yml`と同じ監査済みSHAに固定

## 検証

GitHub Actions上で`workflow_dispatch`またはschedule実行後に以下を確認する。

- 最新版と同じ場合はPRを作らない
- 新版がある場合は`deps/ccstatusline-<version>`からPRを作る
- 通常の`verify` CIがdependency PRにも適用される
