### PR TITLE
fix: WSL検出とシェル設定の責務を整理

### DIFF
--- a/claude/settings.json
+++ b/claude/settings.json
@@ -1,5 +1,6 @@
 {
   "env": {
+    "ENABLE_LSP_TOOL": "1",
     "EDITOR": "zed --wait",
     "VISUAL": "zed --wait"
   },

--- a/config/shell/bash/bashrc
+++ b/config/shell/bash/bashrc
@@ -146,7 +146,7 @@ __bashrc_shopt histappend cmdhist lithist # ヒストリを追記, 複数行コ�
 # ディレクトリ
 __bashrc_shopt autocd cdspell dirspell direxpand # ディレクトリ名だけで cd, cd のタイプミスを修正, 補完時のディレクトリ名タイプミスを修正, Tab補完で変数を展開
 
-# グロブ
+# glob
 __bashrc_shopt globstar nocaseglob extglob # ** で再帰マッチ, 大文字小文字を無視, !(pattern) 等の拡張グロブ
 
 # その他
@@ -274,18 +274,6 @@ if command -v zoxide >/dev/null 2>&1; then
 fi
 
 # ============================================================================
-# ClaudeCode
-# ============================================================================
-
-# WSL/Git Bash: Claude Code powershell.exe 回避
-# ref: https://github.com/anthropics/claude-code/issues/14352
-case "${DOTFILES_PLATFORM:-}" in
-    wsl|windows)
-        export CLAUDE_CODE_SKIP_WINDOWS_PROFILE=1
-        ;;
-esac
-
-# ============================================================================
 # bash固有エイリアス
 # ============================================================================
 
@@ -327,14 +315,3 @@ unset -f __bashrc_eval_output
 unset -f __bashrc_shopt
 unset -f __bashrc_bind
 unset -f __bashrc_add_prompt_command
-
-# ============================================================================
-# PATH 
-# ============================================================================
-export PATH="/home/okayasu/.bun/bin:$PATH"
-
-# ============================================================================
-# Claude LSP
-# ============================================================================
-export ENABLE_LSP_TOOL=1
-

--- a/config/shell/common.sh
+++ b/config/shell/common.sh
@@ -112,7 +112,7 @@ export DOTFILES_PLATFORM
 # ============================================================================
 
 # Windowsホームディレクトリ検出 (Unix形式パスを返す)
-# local/windows.sh, local/wsl.sh から呼ばれる (静的解析では未検出)
+# platform/windows.sh, platform/wsl.sh から呼ばれる (静的解析では未検出)
 # SC2329 (>=0.10) / SC2317 (0.9 は本体を到達不能と誤検出) の両方を抑制する
 # shellcheck disable=SC2317,SC2329
 _dotfiles_detect_win_home() {
@@ -236,7 +236,7 @@ fi
 # ============================================================================
 
 _dotfiles_load_platform() {
-    local platform_file="$DOTFILES_DIR/config/shell/local/${DOTFILES_PLATFORM}.sh"
+    local platform_file="$DOTFILES_DIR/config/shell/platform/${DOTFILES_PLATFORM}.sh"
     if [ -f "$platform_file" ]; then
         . "$platform_file"
     fi

--- a/config/shell/platform/linux.sh
+++ b/config/shell/platform/linux.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
-# shell/local/linux.sh - Linux固有設定 (POSIX互換)
+# shell/platform/linux.sh - Linux固有設定 (POSIX互換)
 #
 # 読み込み元: common.sh (プラットフォーム検出後)
 # 対象: サーバー、デスクトップLinux (WSL以外)
@@ -67,4 +67,3 @@ if command -v systemctl >/dev/null 2>&1; then
     alias jc='journalctl'
     alias jcf='journalctl -f'
 fi
-

--- a/config/shell/platform/macos.sh
+++ b/config/shell/platform/macos.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
-# shell/local/macos.sh - macOS固有設定 (POSIX互換)
+# shell/platform/macos.sh - macOS固有設定 (POSIX互換)
 #
 # 読み込み元: common.sh (プラットフォーム検出後)
 
@@ -79,4 +79,3 @@ if [ -d "$HOMEBREW_PREFIX/opt/openssl@3" ]; then
     export CPPFLAGS="-I$HOMEBREW_PREFIX/opt/openssl@3/include"
     export PKG_CONFIG_PATH="$HOMEBREW_PREFIX/opt/openssl@3/lib/pkgconfig"
 fi
-

--- a/config/shell/platform/windows.sh
+++ b/config/shell/platform/windows.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
-# shell/local/windows.sh - Git Bash (MINGW/MSYS/Cygwin) 固有設定 (POSIX互換)
+# shell/platform/windows.sh - Git Bash (MINGW/MSYS/Cygwin) 固有設定 (POSIX互換)
 #
 # 読み込み元: common.sh (プラットフォーム検出後)
 # 対象: Git Bash on Windows (非WSL)

--- a/config/shell/platform/wsl.sh
+++ b/config/shell/platform/wsl.sh
@@ -1,11 +1,15 @@
 #!/bin/sh
-# shell/local/wsl.sh - WSL固有設定 (POSIX互換)
+# shell/platform/wsl.sh - WSL固有設定 (POSIX互換)
 #
 # 読み込み元: common.sh (プラットフォーム検出後)
 
 # ============================================================================
 # Windows連携
 # ============================================================================
+
+# Claude CodeがWindowsプロファイル検出でpowershell.exeを繰り返し起動するのを防ぐ
+# ref: https://github.com/anthropics/claude-code/issues/14352
+export CLAUDE_CODE_SKIP_WINDOWS_PROFILE=1
 
 # Windowsホームディレクトリ (common.sh の _dotfiles_detect_win_home を使用)
 WIN_HOME="${WIN_HOME:-$(_dotfiles_detect_win_home)}"

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -66,7 +66,12 @@ def _create_fake_mise_shell_runtime(tmp_path: Path) -> tuple[Path, Path, Path]:
 
 
 def _run_bashrc(
-    home: Path, fake_bin: Path, eza_bin: Path
+    home: Path,
+    fake_bin: Path,
+    eza_bin: Path,
+    *,
+    command: str = "alias lla",
+    env_overrides: dict[str, str] | None = None,
 ) -> subprocess.CompletedProcess[str]:
     env = {
         "DOTFILES_DIR": str(REPO_ROOT),
@@ -76,13 +81,14 @@ def _run_bashrc(
         "TERM": "xterm-256color",
         "USER": "test",
     }
+    env.update(env_overrides or {})
     return subprocess.run(
         [
             "/bin/bash",
             "--noprofile",
             "--norc",
             "-ic",
-            f'source "{BASHRC}"; alias lla',
+            f'source "{BASHRC}"; {command}',
         ],
         env=env,
         capture_output=True,
@@ -111,6 +117,63 @@ class TestShellInitialization:
             "alias lla='eza -la --git --group-directories-first --sort=name'"
             in result.stdout
         )
+
+    def test_bash_does_not_export_windows_profile_outside_wsl(
+        self, tmp_path: Path
+    ) -> None:
+        home, fake_bin, eza_bin = _create_fake_mise_shell_runtime(tmp_path)
+        result = _run_bashrc(
+            home,
+            fake_bin,
+            eza_bin,
+            command=(
+                "printf 'platform=%s\\nuserprofile=%s\\nskip=%s\\n' "
+                '"$DOTFILES_PLATFORM" "${USERPROFILE-}" '
+                '"${CLAUDE_CODE_SKIP_WINDOWS_PROFILE-}"'
+            ),
+        )
+
+        assert result.returncode == 0, result.stderr
+        assert "platform=linux" in result.stdout
+        assert "userprofile=\n" in result.stdout
+        assert "skip=\n" in result.stdout
+
+    def test_bash_uses_windows_profile_detected_by_wsl(
+        self, tmp_path: Path
+    ) -> None:
+        home, fake_bin, eza_bin = _create_fake_mise_shell_runtime(tmp_path)
+        _write_executable(
+            fake_bin / "cmd.exe",
+            "#!/bin/sh\nprintf 'C:\\\\Users\\\\work\\r\\n'\n",
+        )
+        _write_executable(
+            fake_bin / "wslpath",
+            "#!/bin/sh\nprintf '/mnt/c/Users/work\\n'\n",
+        )
+        result = _run_bashrc(
+            home,
+            fake_bin,
+            eza_bin,
+            command=(
+                "printf 'platform=%s\\nuserprofile=%s\\nskip=%s\\n' "
+                '"$DOTFILES_PLATFORM" "$USERPROFILE" '
+                '"$CLAUDE_CODE_SKIP_WINDOWS_PROFILE"'
+            ),
+            env_overrides={"WSL_DISTRO_NAME": "Ubuntu"},
+        )
+
+        assert result.returncode == 0, result.stderr
+        assert "platform=wsl" in result.stdout
+        assert "userprofile=/mnt/c/Users/work" in result.stdout
+        assert "skip=1" in result.stdout
+
+    def test_claude_lsp_flag_is_configured_for_claude_not_bash(self) -> None:
+        settings = json.loads(
+            (REPO_ROOT / "claude" / "settings.json").read_text(encoding="utf-8")
+        )
+
+        assert settings["env"]["ENABLE_LSP_TOOL"] == "1"
+        assert "ENABLE_LSP_TOOL" not in BASHRC.read_text(encoding="utf-8")
 
 
 def _run_install_sh(


### PR DESCRIPTION
## 原因

`bashrc`に追加されたWindowsユーザー推測が、既存のplatform検出を迂回していました。

- 非WSLでも`CLAUDE_CODE_SKIP_WINDOWS_PROFILE`と`USERPROFILE`を設定する
- `whoami`はWSLユーザーであり、Windowsユーザーとは限らない
- `/mnt/c/Users`の列挙結果に依存し、環境ごとに結果が変わる
- ShellCheckのSC2155/SC2010によりCIが停止する
- miseのinstall rootは実行ファイルのPATHではない

## 変更

- `config/shell/local/`を責務が明確な`config/shell/platform/`へrename
- WSL固有の`CLAUDE_CODE_SKIP_WINDOWS_PROFILE`を`platform/wsl.sh`へ移動
- `USERPROFILE`は既存の`cmd.exe %USERPROFILE%` + `wslpath`検出を正本として利用
- `ENABLE_LSP_TOOL`をBashからClaude Codeの`settings.json.env`へ移動
- mise install rootの不正なPATH追加と、installer専用変数の常時exportを削除
- WSLと非WSLの回帰テストを追加
- 最新`main`を親にした1コミットへ整理し、競合を解消

## 検証

- `TestShellInitialization`: 4 passed
- `bash -n`, `sh -n`, `zsh -n`: pass
- managed assets regenerate/port/profile/plugin verification: pass, tracked diffなし
- Stow非依存の回帰テスト: 186 passed
- GitHub Actions `verify`: 全job pass