### PR TITLE
fix(ai): harden private knowledge export

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -29,6 +29,7 @@ jobs:
           python3 tests/test_ai_qcd.py
           python3 tests/test_ai_knowledge_sync.py
           python3 tests/test_ai_knowledge_search.py
+          python3 tests/test_ai_knowledge_secret_redaction.py
 
       - name: Require canonical sources to remain unchanged
         run: git diff --exit-code

--- a/bin/ai-knowledge-keygen
+++ b/bin/ai-knowledge-keygen
@@ -1,0 +1,56 @@
+#!/usr/bin/env python3
+"""Create the local HMAC key used by AI knowledge export/redaction."""
+
+from __future__ import annotations
+
+import argparse
+import os
+import secrets
+import sys
+from pathlib import Path
+
+DEFAULT_KEY_FILE = Path.home() / ".config" / "dotfiles" / "ai-knowledge-redaction.key"
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Create an AI knowledge redaction key.")
+    parser.add_argument(
+        "--path",
+        default=os.environ.get("AI_KNOWLEDGE_REDACTION_KEY_FILE", str(DEFAULT_KEY_FILE)),
+        help="key destination (default: ~/.config/dotfiles/ai-knowledge-redaction.key)",
+    )
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    path = Path(args.path).expanduser()
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True, mode=0o700)
+        if os.name == "posix":
+            os.chmod(path.parent, 0o700)
+        descriptor = os.open(path, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
+        try:
+            with os.fdopen(descriptor, "w", encoding="utf-8") as handle:
+                handle.write(secrets.token_hex(32) + "\n")
+        except Exception:
+            try:
+                path.unlink()
+            except OSError:
+                pass
+            raise
+        if os.name == "posix":
+            os.chmod(path, 0o600)
+    except FileExistsError:
+        print(f"ai-knowledge-keygen: refusing to overwrite existing key: {path}", file=sys.stderr)
+        return 1
+    except OSError as error:
+        print(f"ai-knowledge-keygen: {error}", file=sys.stderr)
+        return 1
+
+    print(f"created redaction key: {path}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/bin/ai-knowledge-search
+++ b/bin/ai-knowledge-search
@@ -1,11 +1,14 @@
 #!/usr/bin/env python3
-"""Search current and aggregated project knowledge without loading the corpus."""
+"""Search current and aggregated sanitized project knowledge without loading the corpus."""
 
 from __future__ import annotations
 
 import argparse
+import hashlib
+import hmac
 import json
 import os
+import re
 import sys
 from pathlib import Path
 from typing import Any
@@ -16,8 +19,11 @@ except ModuleNotFoundError as error:  # pragma: no cover - runtime boundary
     raise SystemExit("ai-knowledge-search requires Python 3.11+ (tomllib)") from error
 
 OWNER = "dotfile-work"
+INDEX_SCHEMA_VERSION = 2
 DEFAULT_REPOSITORY = Path.home() / "prog" / "ai-knowledge-private"
+DEFAULT_REDACTION_KEY_FILE = Path.home() / ".config" / "dotfiles" / "ai-knowledge-redaction.key"
 TEXT_SUFFIXES = {".md", ".txt", ".json", ".jsonl", ".toml", ".yaml", ".yml"}
+PROJECT_REF_RE = re.compile(r"^[0-9a-f]{20}$")
 
 
 class SearchError(RuntimeError):
@@ -26,13 +32,20 @@ class SearchError(RuntimeError):
 
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(
-        description="Search reusable .ai knowledge across current and collected projects."
+        description="Search reusable .ai knowledge across current and sanitized collected projects."
     )
     parser.add_argument("terms", nargs="+", help="terms that should influence ranking")
     parser.add_argument(
         "--repository",
         default=os.environ.get("AI_KNOWLEDGE_REPOSITORY", str(DEFAULT_REPOSITORY)),
         help="aggregated private repository (default: ~/prog/ai-knowledge-private)",
+    )
+    parser.add_argument(
+        "--redaction-key-file",
+        default=os.environ.get(
+            "AI_KNOWLEDGE_REDACTION_KEY_FILE", str(DEFAULT_REDACTION_KEY_FILE)
+        ),
+        help="HMAC key file used to identify the current project's sanitized aggregate",
     )
     parser.add_argument("--include-inbox", action="store_true")
     parser.add_argument("--limit", type=int, default=20)
@@ -64,6 +77,30 @@ def find_current_project(start: Path) -> tuple[Path, str] | None:
     return None
 
 
+def load_redaction_key(path: Path) -> bytes:
+    path = path.expanduser()
+    if not path.exists():
+        raise SearchError(
+            f"redaction key not found: {path}; create it with ai-knowledge-keygen"
+        )
+    if path.is_symlink() or not path.is_file():
+        raise SearchError(f"redaction key must be a regular non-symlink file: {path}")
+    if os.name == "posix" and path.stat().st_mode & 0o077:
+        raise SearchError(f"redaction key permissions must be 0600 or stricter: {path}")
+    try:
+        key = path.read_bytes().strip()
+    except OSError as error:
+        raise SearchError(f"cannot read redaction key {path}: {error}") from error
+    if len(key) < 32:
+        raise SearchError("redaction key must contain at least 32 bytes")
+    return key
+
+
+def project_ref(key: bytes, project_id: str) -> str:
+    payload = f"project\0{project_id}".encode("utf-8")
+    return hmac.new(key, payload, hashlib.sha256).hexdigest()[:20]
+
+
 def load_index(repository: Path) -> list[dict[str, str]]:
     path = repository / "index.json"
     if not path.is_file():
@@ -73,30 +110,31 @@ def load_index(repository: Path) -> list[dict[str, str]]:
     except (OSError, UnicodeDecodeError, json.JSONDecodeError) as error:
         raise SearchError(f"invalid knowledge index {path}: {error}") from error
     projects = data.get("projects")
-    if data.get("schema_version") != 1 or not isinstance(projects, list):
+    if data.get("schema_version") == 1:
+        raise SearchError(
+            "legacy knowledge index schema 1 is intentionally unsupported because it may "
+            "contain unsanitized project identifiers; rebuild the private repository first"
+        )
+    if data.get("schema_version") != INDEX_SCHEMA_VERSION or not isinstance(projects, list):
         raise SearchError(f"unsupported knowledge index: {path}")
 
     entries: list[dict[str, str]] = []
     for item in projects:
         if not isinstance(item, dict):
             raise SearchError(f"invalid project entry in {path}")
-        project_id = item.get("project_id")
+        ref = item.get("project_ref")
         relative = item.get("path")
-        if not isinstance(project_id, str) or not isinstance(relative, str):
-            raise SearchError(f"invalid project entry in {path}")
-        value = Path(relative)
-        if (
-            value.is_absolute()
-            or len(value.parts) != 2
-            or value.parts[0] != "projects"
-            or value.parts[1] in {"", ".", ".."}
-        ):
+        if not isinstance(ref, str) or not PROJECT_REF_RE.fullmatch(ref):
+            raise SearchError(f"invalid project_ref in {path}")
+        if not isinstance(relative, str) or relative != f"projects/{ref}":
             raise SearchError(f"unsafe project path in {path}: {relative}")
-        entries.append({"project_id": project_id, "path": relative})
+        entries.append({"project_ref": ref, "path": relative})
     return entries
 
 
-def source_roots(repository: Path, include_inbox: bool) -> list[tuple[str, str, Path]]:
+def source_roots(
+    repository: Path, include_inbox: bool, redaction_key_file: Path
+) -> list[tuple[str, str, Path]]:
     sources: list[tuple[str, str, Path]] = []
     current = find_current_project(Path.cwd())
     current_id: str | None = None
@@ -110,16 +148,19 @@ def source_roots(repository: Path, include_inbox: bool) -> list[tuple[str, str, 
 
     if repository.is_dir() and (repository / "index.json").is_file():
         repository = repository.expanduser().resolve()
-        for entry in load_index(repository):
-            project_id = entry["project_id"]
-            if project_id == current_id:
+        entries = load_index(repository)
+        key = load_redaction_key(redaction_key_file)
+        current_ref = project_ref(key, current_id) if current_id is not None else None
+        for entry in entries:
+            ref = entry["project_ref"]
+            if ref == current_ref:
                 continue
             base = repository / entry["path"]
             kinds = ("knowledge", "inbox") if include_inbox else ("knowledge",)
             for kind in kinds:
                 root = base / kind
                 if root.is_dir():
-                    sources.append((project_id, kind, root))
+                    sources.append((ref, kind, root))
     return sources
 
 
@@ -153,8 +194,9 @@ def search(args: argparse.Namespace) -> list[dict[str, Any]]:
         raise SearchError("at least one non-empty search term is required")
 
     repository = Path(args.repository).expanduser()
+    key_file = Path(args.redaction_key_file).expanduser()
     results: list[dict[str, Any]] = []
-    for project_id, kind, root in source_roots(repository, args.include_inbox):
+    for project_id, kind, root in source_roots(repository, args.include_inbox, key_file):
         for path in sorted(root.rglob("*")):
             if (
                 not path.is_file()

--- a/bin/ai-knowledge-sync
+++ b/bin/ai-knowledge-sync
@@ -1,12 +1,14 @@
 #!/usr/bin/env python3
-"""Collect managed project .ai/ state into one private Git repository."""
+"""Export sanitized project AI knowledge into one private Git repository."""
 
 from __future__ import annotations
 
 import argparse
 import datetime as dt
 import hashlib
+import hmac
 import json
+import math
 import os
 import re
 import shutil
@@ -21,12 +23,39 @@ except ModuleNotFoundError as error:  # pragma: no cover - runtime boundary
     raise SystemExit("ai-knowledge-sync requires Python 3.11+ (tomllib)") from error
 
 OWNER = "dotfile-work"
-SCHEMA_VERSION = 1
+MANIFEST_SCHEMA_VERSION = 1
+INDEX_SCHEMA_VERSION = 2
 DEFAULT_MAX_FILE_BYTES = 2 * 1024 * 1024
 DEFAULT_REPOSITORY = Path.home() / "prog" / "ai-knowledge-private"
+DEFAULT_REDACTION_KEY_FILE = Path.home() / ".config" / "dotfiles" / "ai-knowledge-redaction.key"
+EXPORT_KINDS = ("knowledge", "inbox")
+TEXT_SUFFIXES = {".md", ".txt", ".json", ".jsonl", ".toml", ".yaml", ".yml"}
 SENSITIVE_SUFFIXES = {".pem", ".key", ".p12", ".pfx", ".jks", ".keystore"}
 SENSITIVE_NAMES = {".env", "id_rsa", "id_ed25519"}
 SENSITIVE_PARTS = {"secrets", ".git"}
+PROJECT_REF_RE = re.compile(r"^[0-9a-f]{20}$")
+PRIVATE_MARKER_RE = re.compile(
+    r"\{\{private:(?P<kind>[a-z][a-z0-9_-]{0,31}):(?P<value>.*?)\}\}", re.DOTALL
+)
+REDACT_MARKER_RE = re.compile(r"\{\{redact:(?P<value>.*?)\}\}", re.DOTALL)
+SECRET_PATTERNS = (
+    ("private key", re.compile(r"-----BEGIN (?:[A-Z0-9 ]+ )?PRIVATE KEY-----")),
+    ("GitHub token", re.compile(r"\b(?:gh[pousr]_[A-Za-z0-9_]{20,}|github_pat_[A-Za-z0-9_]{20,})\b")),
+    ("OpenAI-style API key", re.compile(r"\bsk-[A-Za-z0-9_-]{20,}\b")),
+    ("AWS access key", re.compile(r"\bAKIA[0-9A-Z]{16}\b")),
+    ("Slack token", re.compile(r"\bxox[baprs]-[A-Za-z0-9-]{20,}\b")),
+    ("Authorization bearer header", re.compile(r"(?im)^\s*Authorization\s*:\s*Bearer\s+\S+")),
+    ("cookie header", re.compile(r"(?im)^\s*(?:Cookie|Set-Cookie)\s*:\s*\S+")),
+    (
+        "credential assignment",
+        re.compile(
+            r"(?im)\b(?:password|passwd|pwd|secret|token|api[_-]?key|access[_-]?key|client[_-]?secret)\b"
+            r"\s*[:=]\s*[\"']?(?P<value>[^\s\"'`;,]{8,})"
+        ),
+    ),
+)
+SAFE_PLACEHOLDER_RE = re.compile(r"^<(?:redacted|[a-z][a-z0-9_-]{0,31}:[0-9a-f]{12})>$")
+HIGH_ENTROPY_RE = re.compile(r"(?<![A-Za-z0-9+/=_-])([A-Za-z0-9+/=_-]{40,})(?![A-Za-z0-9+/=_-])")
 
 
 class SyncError(RuntimeError):
@@ -35,7 +64,7 @@ class SyncError(RuntimeError):
 
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(
-        description="Collect managed ~/prog/*/.ai into a private knowledge repository."
+        description="Export sanitized managed ~/prog/*/.ai knowledge into a private repository."
     )
     parser.add_argument(
         "--source-root",
@@ -48,10 +77,17 @@ def parse_args() -> argparse.Namespace:
         help="checked-out private Git repository (default: ~/prog/ai-knowledge-private)",
     )
     parser.add_argument(
+        "--redaction-key-file",
+        default=os.environ.get(
+            "AI_KNOWLEDGE_REDACTION_KEY_FILE", str(DEFAULT_REDACTION_KEY_FILE)
+        ),
+        help="HMAC key file used for pseudonymous project/file references",
+    )
+    parser.add_argument(
         "--max-file-bytes",
         type=int,
         default=DEFAULT_MAX_FILE_BYTES,
-        help=f"reject larger .ai files (default: {DEFAULT_MAX_FILE_BYTES})",
+        help=f"reject larger exportable files (default: {DEFAULT_MAX_FILE_BYTES})",
     )
     parser.add_argument("--dry-run", action="store_true")
     parser.add_argument(
@@ -116,7 +152,7 @@ def load_manifest(path: Path) -> dict[str, object]:
     except (OSError, UnicodeDecodeError, tomllib.TOMLDecodeError) as error:
         raise SyncError(f"invalid managed manifest {path}: {error}") from error
 
-    if data.get("schema_version") != SCHEMA_VERSION:
+    if data.get("schema_version") != MANIFEST_SCHEMA_VERSION:
         raise SyncError(f"unsupported schema_version in {path}")
     if data.get("owner") != OWNER:
         raise SyncError(f"unexpected .ai owner in managed manifest {path}")
@@ -129,10 +165,51 @@ def load_manifest(path: Path) -> dict[str, object]:
     if not isinstance(export, dict):
         raise SyncError(f"invalid [export] table in {path}")
     enabled = export.get("enabled", True)
+    include_inbox = export.get("include_inbox", False)
     if not isinstance(enabled, bool):
         raise SyncError(f"export.enabled must be boolean in {path}")
+    if not isinstance(include_inbox, bool):
+        raise SyncError(f"export.include_inbox must be boolean in {path}")
 
-    return {"project_id": project_id, "enabled": enabled}
+    return {
+        "project_id": project_id,
+        "enabled": enabled,
+        "include_inbox": include_inbox,
+    }
+
+
+def load_redaction_key(path: Path) -> bytes:
+    path = path.expanduser()
+    if not path.exists():
+        raise SyncError(
+            f"redaction key not found: {path}; create it with ai-knowledge-keygen"
+        )
+    if path.is_symlink() or not path.is_file():
+        raise SyncError(f"redaction key must be a regular non-symlink file: {path}")
+    if os.name == "posix" and path.stat().st_mode & 0o077:
+        raise SyncError(f"redaction key permissions must be 0600 or stricter: {path}")
+    try:
+        key = path.read_bytes().strip()
+    except OSError as error:
+        raise SyncError(f"cannot read redaction key {path}: {error}") from error
+    if len(key) < 32:
+        raise SyncError("redaction key must contain at least 32 bytes")
+    return key
+
+
+def digest_ref(key: bytes, namespace: str, value: str, length: int) -> str:
+    payload = f"{namespace}\0{value}".encode("utf-8")
+    return hmac.new(key, payload, hashlib.sha256).hexdigest()[:length]
+
+
+def project_ref(key: bytes, project_id: str) -> str:
+    return digest_ref(key, "project", project_id, 20)
+
+
+def file_ref(key: bytes, project: str, kind: str, relative: Path) -> str:
+    suffix = relative.suffix.lower() if relative.suffix.lower() in TEXT_SUFFIXES else ".txt"
+    identity = f"{project}\0{kind}\0{relative.as_posix()}"
+    return f"{digest_ref(key, 'file', identity, 20)}{suffix}"
 
 
 def sensitive_path(relative: Path) -> bool:
@@ -145,37 +222,139 @@ def sensitive_path(relative: Path) -> bool:
     return relative.suffix.lower() in SENSITIVE_SUFFIXES
 
 
-def validate_ai_tree(root: Path, max_file_bytes: int) -> None:
-    for path in sorted(root.rglob("*")):
-        relative = path.relative_to(root)
-        if path.is_symlink():
-            raise SyncError(f"symlink is not exportable: {root / relative}")
-        if path.is_dir():
-            continue
-        if not path.is_file():
-            raise SyncError(f"unsupported filesystem entry: {root / relative}")
-        if sensitive_path(relative):
-            raise SyncError(f"sensitive-looking path is not exportable: {root / relative}")
-        size = path.stat().st_size
-        if size > max_file_bytes:
-            raise SyncError(
-                f"file exceeds --max-file-bytes ({size} > {max_file_bytes}): {root / relative}"
+def shannon_entropy(value: str) -> float:
+    counts = {character: value.count(character) for character in set(value)}
+    length = len(value)
+    return -sum(
+        (count / length) * math.log2(count / length) for count in counts.values()
+    )
+
+
+def assert_no_secret(text: str, source: Path) -> None:
+    for label, pattern in SECRET_PATTERNS:
+        for match in pattern.finditer(text):
+            value = match.groupdict().get("value")
+            if value is not None and SAFE_PLACEHOLDER_RE.fullmatch(value):
+                continue
+            raise SyncError(f"{label} detected in exportable knowledge: {source}")
+
+    for match in HIGH_ENTROPY_RE.finditer(text):
+        candidate = match.group(1)
+        classes = sum(
+            (
+                any(character.islower() for character in candidate),
+                any(character.isupper() for character in candidate),
+                any(character.isdigit() for character in candidate),
+                any(character in "+/=_-" for character in candidate),
             )
-        with path.open("rb") as handle:
-            if b"\0" in handle.read(min(size, 8192)):
-                raise SyncError(f"binary file is not exportable: {root / relative}")
+        )
+        if classes >= 3 and shannon_entropy(candidate) >= 4.2:
+            raise SyncError(f"high-entropy token detected in exportable knowledge: {source}")
 
 
-def project_key(project_id: str) -> str:
-    readable = re.sub(r"[^A-Za-z0-9._-]+", "__", project_id).strip("._-")
-    if not readable:
-        readable = "project"
-    digest = hashlib.sha256(project_id.encode("utf-8")).hexdigest()[:12]
-    return f"{readable[:96]}--{digest}"
+def pseudonymize_text(
+    text: str, *, key: bytes, project: Path, project_id: str, source: Path
+) -> str:
+    def replace_private(match: re.Match[str]) -> str:
+        kind = match.group("kind")
+        value = match.group("value").strip()
+        if not value:
+            raise SyncError(f"empty private marker in {source}")
+        token = digest_ref(key, f"private:{kind}", value, 12)
+        return f"<{kind}:{token}>"
+
+    def replace_redact(match: re.Match[str]) -> str:
+        value = match.group("value")
+        if not value.strip():
+            raise SyncError(f"empty redact marker in {source}")
+        return "<redacted>"
+
+    sanitized = PRIVATE_MARKER_RE.sub(replace_private, text)
+    sanitized = REDACT_MARKER_RE.sub(replace_redact, sanitized)
+    if "{{private:" in sanitized or "{{redact:" in sanitized:
+        raise SyncError(f"malformed redaction marker in {source}")
+
+    replacements = [
+        (str(project.resolve()), "$PROJECT"),
+        (str(Path.home().resolve()), "$HOME"),
+    ]
+    for raw, placeholder in sorted(replacements, key=lambda item: len(item[0]), reverse=True):
+        if raw and raw not in {"/", "."}:
+            sanitized = sanitized.replace(raw, placeholder)
+
+    # A raw project identifier is metadata, not reusable knowledge. Avoid exporting it even
+    # when it appears in a note by accident.
+    sanitized = sanitized.replace(project_id, f"<project:{project_ref(key, project_id)}>")
+    assert_no_secret(sanitized, source)
+    return sanitized
 
 
-def discover_projects(source_root: Path, repository: Path) -> list[tuple[Path, Path, str]]:
-    projects: list[tuple[Path, Path, str]] = []
+def validate_source_file(path: Path, relative: Path, max_file_bytes: int) -> None:
+    if path.is_symlink():
+        raise SyncError(f"symlink is not exportable: {path}")
+    if not path.is_file():
+        raise SyncError(f"unsupported filesystem entry: {path}")
+    if sensitive_path(relative):
+        raise SyncError(f"sensitive-looking path is not exportable: {path}")
+    if path.suffix.lower() not in TEXT_SUFFIXES:
+        raise SyncError(f"unsupported export file type: {path}")
+    size = path.stat().st_size
+    if size > max_file_bytes:
+        raise SyncError(
+            f"file exceeds --max-file-bytes ({size} > {max_file_bytes}): {path}"
+        )
+    with path.open("rb") as handle:
+        if b"\0" in handle.read(min(size, 8192)):
+            raise SyncError(f"binary file is not exportable: {path}")
+
+
+def selected_kinds(include_inbox: bool) -> tuple[str, ...]:
+    return EXPORT_KINDS if include_inbox else ("knowledge",)
+
+
+def prepare_project_export(
+    *,
+    project: Path,
+    ai_root: Path,
+    project_id: str,
+    include_inbox: bool,
+    key: bytes,
+    destination: Path,
+    max_file_bytes: int,
+) -> None:
+    ref = project_ref(key, project_id)
+    for kind in selected_kinds(include_inbox):
+        source_root = ai_root / kind
+        if not source_root.exists():
+            continue
+        if source_root.is_symlink() or not source_root.is_dir():
+            raise SyncError(f"export source must be a directory: {source_root}")
+        output_root = destination / kind
+        for path in sorted(source_root.rglob("*")):
+            if path.is_dir() and not path.is_symlink():
+                continue
+            relative = path.relative_to(source_root)
+            validate_source_file(path, relative, max_file_bytes)
+            try:
+                text = path.read_text(encoding="utf-8")
+            except (OSError, UnicodeDecodeError) as error:
+                raise SyncError(f"exportable knowledge must be UTF-8 text: {path}") from error
+            sanitized = pseudonymize_text(
+                text,
+                key=key,
+                project=project,
+                project_id=project_id,
+                source=path,
+            )
+            output_root.mkdir(parents=True, exist_ok=True)
+            output = output_root / file_ref(key, ref, kind, relative)
+            output.write_text(sanitized, encoding="utf-8")
+
+
+def discover_projects(
+    source_root: Path, repository: Path
+) -> list[tuple[Path, Path, str, bool]]:
+    projects: list[tuple[Path, Path, str, bool]] = []
     repository = repository.resolve()
     for project in sorted(source_root.iterdir(), key=lambda path: path.name):
         if not project.is_dir() or project.is_symlink():
@@ -194,30 +373,21 @@ def discover_projects(source_root: Path, repository: Path) -> list[tuple[Path, P
         manifest = load_manifest(manifest_path)
         if not manifest["enabled"]:
             continue
-        project_id = str(manifest["project_id"])
-        projects.append((project, ai_root, project_id))
+        projects.append(
+            (
+                project,
+                ai_root,
+                str(manifest["project_id"]),
+                bool(manifest["include_inbox"]),
+            )
+        )
     return projects
-
-
-def copy_project(ai_root: Path, destination: Path) -> None:
-    destination.parent.mkdir(parents=True, exist_ok=True)
-    temporary = Path(
-        tempfile.mkdtemp(prefix=f".{destination.name}-", dir=destination.parent)
-    )
-    try:
-        shutil.copytree(ai_root, temporary / "tree", dirs_exist_ok=True)
-        staged = temporary / "tree"
-        if destination.exists():
-            shutil.rmtree(destination)
-        os.replace(staged, destination)
-    finally:
-        shutil.rmtree(temporary, ignore_errors=True)
 
 
 def write_index(repository: Path, entries: list[dict[str, str]]) -> None:
     payload = {
-        "schema_version": 1,
-        "projects": sorted(entries, key=lambda item: item["project_id"]),
+        "schema_version": INDEX_SCHEMA_VERSION,
+        "projects": sorted(entries, key=lambda item: item["project_ref"]),
     }
     (repository / "index.json").write_text(
         json.dumps(payload, ensure_ascii=False, indent=2, sort_keys=True) + "\n",
@@ -234,18 +404,29 @@ def load_previous_managed_paths(repository: Path) -> set[str]:
         projects = data.get("projects", [])
     except (OSError, UnicodeDecodeError, json.JSONDecodeError) as error:
         raise SyncError(f"invalid managed index {path}: {error}") from error
-    if data.get("schema_version") != 1 or not isinstance(projects, list):
+
+    schema = data.get("schema_version")
+    if schema == 1:
+        raise SyncError(
+            "legacy knowledge index schema 1 detected; it may contain raw .ai content and "
+            "project identifiers in Git history. Recreate the private repository or purge "
+            "its history before using the hardened exporter"
+        )
+    if schema != INDEX_SCHEMA_VERSION or not isinstance(projects, list):
         raise SyncError(f"unsupported managed index: {path}")
 
     managed: set[str] = set()
     for item in projects:
-        value = item.get("path") if isinstance(item, dict) else None
+        if not isinstance(item, dict):
+            raise SyncError(f"invalid project entry in managed index: {path}")
+        ref = item.get("project_ref")
+        value = item.get("path")
+        if not isinstance(ref, str) or not PROJECT_REF_RE.fullmatch(ref):
+            raise SyncError(f"invalid project_ref in managed index: {path}")
         if not isinstance(value, str):
             raise SyncError(f"invalid project path in managed index: {path}")
         relative = Path(value)
-        if relative.is_absolute() or len(relative.parts) != 2:
-            raise SyncError(f"unsafe project path in managed index: {value}")
-        if relative.parts[0] != "projects" or relative.parts[1] in {"", ".", ".."}:
+        if relative.as_posix() != f"projects/{ref}":
             raise SyncError(f"unsafe project path in managed index: {value}")
         managed.add(relative.as_posix())
     return managed
@@ -258,6 +439,15 @@ def prune_stale_projects(repository: Path, previous: set[str], desired: set[str]
             if target.is_symlink() or not target.is_dir():
                 raise SyncError(f"managed project path is not a directory: {relative}")
             shutil.rmtree(target)
+
+
+def replace_project_export(source: Path, destination: Path) -> None:
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    if destination.exists():
+        if destination.is_symlink() or not destination.is_dir():
+            raise SyncError(f"managed project destination is not a directory: {destination}")
+        shutil.rmtree(destination)
+    shutil.copytree(source, destination)
 
 
 def stage_and_commit(repository: Path) -> bool:
@@ -273,7 +463,7 @@ def stage_and_commit(repository: Path) -> bool:
         raise SyncError("cannot inspect staged knowledge diff")
 
     date = dt.date.today().isoformat()
-    run_git(repository, "commit", "-m", f"chore: sync ai knowledge {date}")
+    run_git(repository, "commit", "-m", f"chore: sync sanitized ai knowledge {date}")
     return True
 
 
@@ -283,47 +473,66 @@ def sync(args: argparse.Namespace) -> int:
 
     source_root = Path(args.source_root).expanduser().resolve()
     repository = Path(args.repository).expanduser().resolve()
+    key_path = Path(args.redaction_key_file).expanduser()
     if not source_root.is_dir():
         raise SyncError(f"source root does not exist: {source_root}")
 
     ensure_git_repository(repository)
     ensure_clean(repository)
-
+    key = load_redaction_key(key_path)
     projects = discover_projects(source_root, repository)
+    previous = load_previous_managed_paths(repository)
+
     seen_ids: set[str] = set()
-    prepared: list[tuple[Path, str, str]] = []
+    seen_refs: set[str] = set()
     entries: list[dict[str, str]] = []
 
-    # Validate every selected source before mutating the destination repository.
-    for project, ai_root, project_id in projects:
-        if project_id in seen_ids:
-            raise SyncError(f"duplicate project_id: {project_id}")
-        seen_ids.add(project_id)
-        validate_ai_tree(ai_root, args.max_file_bytes)
-        key = project_key(project_id)
-        relative = f"projects/{key}"
-        prepared.append((ai_root, relative, project.name))
-        entries.append({"project_id": project_id, "path": relative})
+    # Build every sanitized export in a temporary tree before mutating the destination.
+    with tempfile.TemporaryDirectory(prefix="ai-knowledge-export-") as directory:
+        prepared_root = Path(directory)
+        prepared: list[tuple[Path, str, str]] = []
+        for project, ai_root, project_id, include_inbox in projects:
+            if project_id in seen_ids:
+                raise SyncError(f"duplicate project_id: {project_id}")
+            seen_ids.add(project_id)
+            ref = project_ref(key, project_id)
+            if ref in seen_refs:
+                raise SyncError("pseudonymous project reference collision")
+            seen_refs.add(ref)
+            relative = f"projects/{ref}"
+            staged = prepared_root / ref
+            staged.mkdir(parents=True)
+            prepare_project_export(
+                project=project,
+                ai_root=ai_root,
+                project_id=project_id,
+                include_inbox=include_inbox,
+                key=key,
+                destination=staged,
+                max_file_bytes=args.max_file_bytes,
+            )
+            prepared.append((staged, relative, project.name))
+            entries.append({"project_ref": ref, "path": relative})
 
-    previous = load_previous_managed_paths(repository)
-    desired = {entry["path"] for entry in entries}
+        desired = {entry["path"] for entry in entries}
+        if args.dry_run:
+            for _, relative, project_name in prepared:
+                print(f"would export sanitized: {project_name} -> {relative}")
+            for relative in sorted(previous - desired):
+                print(f"would prune: {relative}")
+            print(f"projects selected: {len(entries)}")
+            return 0
 
-    if args.dry_run:
-        for _, relative, project_name in prepared:
-            print(f"would sync: {project_name} -> {relative}")
-        for relative in sorted(previous - desired):
-            print(f"would prune: {relative}")
-        print(f"projects selected: {len(entries)}")
-        return 0
-
-    prune_stale_projects(repository, previous, desired)
-    for ai_root, relative, _ in prepared:
-        copy_project(ai_root, repository / relative)
+        prune_stale_projects(repository, previous, desired)
+        for staged, relative, _ in prepared:
+            replace_project_export(staged, repository / relative)
 
     (repository / "projects").mkdir(parents=True, exist_ok=True)
     write_index(repository, entries)
     committed = stage_and_commit(repository)
-    print(f"projects synced: {len(entries)}; committed: {'yes' if committed else 'no'}")
+    print(
+        f"projects exported: {len(entries)}; committed: {'yes' if committed else 'no'}"
+    )
 
     if not args.no_push:
         run_git(repository, "push")

--- a/bin/ai-knowledge-sync
+++ b/bin/ai-knowledge-sync
@@ -255,6 +255,10 @@ def assert_no_secret(text: str, source: Path) -> None:
 def pseudonymize_text(
     text: str, *, key: bytes, project: Path, project_id: str, source: Path
 ) -> str:
+    # Scan raw text before marker substitution so secrets cannot be hidden inside
+    # {{private:...}} or {{redact:...}} and converted into a stored pseudonym.
+    assert_no_secret(text, source)
+
     def replace_private(match: re.Match[str]) -> str:
         kind = match.group("kind")
         value = match.group("value").strip()

--- a/common/rules/project-ai-knowledge.md
+++ b/common/rules/project-ai-knowledge.md
@@ -39,12 +39,26 @@ A single successful attempt is not enough to turn a candidate into a global rule
 
 The project-local `.ai/` directory is the only source that the cross-project collector should export. Do not make the collector scrape `.claude/`, `.codex/`, `claude_tmp/`, or `codex_tmp/` directly.
 
-Runtime-specific adapters may inspect their own state and explicitly harvest reusable findings into `.ai/inbox/`. This keeps backup/export independent from runtime-specific file formats and prevents raw logs or scratch data from becoming durable knowledge by accident.
+The private aggregate is a **sanitized export view**, not a backup of `.ai/`:
 
-Managed `.ai/` projects are included in sibling collection by default. Set `[export].enabled = false` only when a specific project must be excluded from the external private knowledge repository.
+- `.ai/knowledge/` is exportable by default.
+- `.ai/inbox/` is exported only when `[export].include_inbox = true`.
+- `.ai/state/` and `.ai/manifest.toml` are never exported.
+- project IDs, source file names, and source directory names are replaced by keyed HMAC references in the aggregate.
 
-## Privacy
+Runtime-specific adapters may inspect their own state and explicitly harvest reusable findings into `.ai/inbox/`. This keeps export independent from runtime-specific file formats and prevents raw logs or scratch data from becoming durable cross-project knowledge by accident.
 
-`.ai/` is private local state and is excluded by the global gitignore. The cross-project repository is also private, but export remains an external write: reusable knowledge must not contain credentials, tokens, private keys, environment files, raw secret-bearing logs, or customer-confidential source contents.
+Managed `.ai/` projects are included in sibling collection by default. Set `[export].enabled = false` when a project must be excluded from the external private knowledge repository. Keep `export.include_inbox = false` unless cross-project reuse of unverified candidates is intentionally required.
 
-Preserve the decision-relevant abstraction and evidence reference instead of copying sensitive source material.
+## Privacy and redaction
+
+Treat the aggregate as a sanitized knowledge warehouse, not as a place where private data is acceptable merely because the GitHub repository is private.
+
+- `secret`: credentials, tokens, private keys, cookies, authorization headers, environment secrets. Never export. Secret detection is fail-closed; do not commit a masked copy as a substitute.
+- `confidential`: customer names, internal hosts, incident IDs, employee identifiers, private project labels. Preserve only the decision-relevant abstraction. Use `{{private:<kind>:<value>}}` when stable pseudonymous correlation is useful, or `{{redact:<value>}}` when it is not.
+- `internal`: non-secret project-specific context. Export only if it is reusable and does not reveal confidential source material.
+- `public`: generally reusable information that still belongs in project knowledge rather than an always-loaded rule.
+
+The HMAC redaction key is local-only and must never be committed. Generate it with `ai-knowledge-keygen`; the exporter requires a regular key file with private permissions. Automatic semantic detection cannot reliably identify every customer/company name, so confidential identifiers must be marked or abstracted before they reach `knowledge/`.
+
+Operational controls, key handling, legacy-repository migration, and incident recovery are defined in `docs/ai-knowledge-private.md`.

--- a/docs/ai-knowledge-private.md
+++ b/docs/ai-knowledge-private.md
@@ -1,0 +1,136 @@
+# Private AI Knowledge Repository Policy
+
+The aggregate repository is a **sanitized, derived knowledge store**. It is not a backup destination for raw `.ai/`, runtime logs, source code, credentials, or customer data.
+
+## Export boundary
+
+`ai-knowledge-sync` reads only managed project `.ai/` directories, then builds a temporary sanitized tree before touching the destination repository.
+
+| Local source | Default aggregate behavior |
+| --- | --- |
+| `.ai/knowledge/` | export after validation/redaction |
+| `.ai/inbox/` | excluded; opt in with `export.include_inbox = true` |
+| `.ai/state/` | never export |
+| `.ai/manifest.toml` | never export |
+| `.claude/`, `.codex/`, `*_tmp/` | never read by collector |
+
+Only UTF-8 text files with the supported knowledge suffixes are exportable. Symlinks, binary files, sensitive-looking paths, unsupported file types, and oversized files fail the entire sync before destination mutation.
+
+Project IDs and source paths are not written to the aggregate. A local HMAC key derives opaque project references and opaque file names. Absolute local paths are normalized to `$PROJECT` / `$HOME` when found in exported text.
+
+## Data classification
+
+Use the following decision before writing reusable knowledge:
+
+| Class | Examples | Export rule |
+| --- | --- | --- |
+| `public` | generic technical finding | allowed |
+| `internal` | non-sensitive project context | allowed only when reusable |
+| `confidential` | customer/company names, internal hosts, incident IDs, private labels | abstract or pseudonymize before export |
+| `secret` | password, API token, private key, cookie, bearer token | prohibited; sync must fail |
+
+A private GitHub repository does not lower the classification of its contents.
+
+## Redaction syntax
+
+For a confidential value whose identity must remain correlatable across findings, use an explicit private marker in the local knowledge file:
+
+```text
+{{private:customer:Example Corporation}}
+{{private:host:prod-db-01.internal}}
+```
+
+The aggregate stores deterministic HMAC-derived placeholders such as:
+
+```text
+<customer:5b8f2e3d96c1>
+<host:84e1177d3850>
+```
+
+The original values are not written to the aggregate. The same `kind + value` under the same local HMAC key produces the same pseudonym.
+
+For one-off data that should not remain correlatable, use:
+
+```text
+{{redact:INC-12345}}
+```
+
+which becomes:
+
+```text
+<redacted>
+```
+
+Do not use masking such as `secret=****` as a way to permit secret-bearing records. Remove the record or extract a reusable abstraction instead.
+
+The exporter also rejects recognized credential formats, credential assignments, authorization/cookie headers, private-key blocks, and suspicious high-entropy tokens. This is a guardrail, not semantic DLP: customer names and business-confidential prose cannot be identified reliably without explicit abstraction/redaction.
+
+## HMAC key
+
+Create the key once on each machine that must produce or search the same aggregate:
+
+```bash
+ai-knowledge-keygen
+```
+
+Default path:
+
+```text
+~/.config/dotfiles/ai-knowledge-redaction.key
+```
+
+Requirements:
+
+- keep the file outside every Git repository;
+- permission `0600` or stricter on POSIX;
+- do not pass the key value through shell arguments or environment variables;
+- back it up only through an encrypted secret/credential backup mechanism;
+- use the same key on machines that must derive the same project/file references.
+
+`AI_KNOWLEDGE_REDACTION_KEY_FILE` changes the key path without exposing the key value.
+
+Rotating the key changes every pseudonymous project/file reference. If rotation is caused by suspected key disclosure, rebuild the aggregate history rather than committing a normal rename-only migration.
+
+## Private repository controls
+
+The destination repository should be dedicated to this dataset and have no unrelated worktree changes.
+
+Required operating rules:
+
+- repository visibility is **private**;
+- grant access only to accounts that require the knowledge corpus;
+- use a dedicated Git credential with the minimum repository-content permissions needed for sync;
+- keep Pages, public forks, and unnecessary integrations disabled;
+- disable Actions/third-party apps unless the aggregate has a specific audited need for them;
+- enable GitHub secret scanning/protection features when available;
+- keep the local clone on encrypted storage;
+- do not manually copy raw `.ai/`, source files, logs, or incident dumps into the repository;
+- treat generated `projects/` and `index.json` as collector-owned output rather than hand-edited content.
+
+Before enabling scheduled push, verify the remote repository's visibility and credential scope manually. The local collector intentionally does not depend on network/API access to prove GitHub visibility on every run.
+
+## Legacy schema 1 migration
+
+The old collector copied broad `.ai/` content and stored readable project IDs. A normal follow-up commit cannot remove that data from Git history.
+
+If `index.json` uses `schema_version = 1`, the hardened exporter and search command fail closed. Use one of these approaches before re-enabling scheduled sync:
+
+1. **Preferred when the aggregate is disposable:** create a fresh private repository, create/restore the HMAC key, and run the hardened exporter into the empty repository.
+2. **When history must be retained:** audit the old repository, remove sensitive paths/identifiers with a history-rewrite tool such as `git filter-repo`, force-push the rewritten history, invalidate old clones, then rebuild the schema-2 aggregate.
+
+Do not simply change `schema_version` by hand.
+
+## Incident response
+
+If secret or confidential raw data reaches the aggregate:
+
+1. stop scheduled sync and set the affected project's `export.enabled = false`;
+2. if a credential is involved, revoke/rotate it first;
+3. identify every affected file/commit and whether clones/remotes may contain it;
+4. purge affected data from Git history or recreate the aggregate repository;
+5. force-push only after the rewrite is verified;
+6. delete/re-clone every stale local copy that still contains the old objects;
+7. add a regression case or detection rule that prevents the same leak class;
+8. re-enable export only after the sanitized dry-run is reviewed.
+
+Deletion in a later commit is not sufficient for a secret that already entered Git history.

--- a/tests/test_ai_knowledge_search.py
+++ b/tests/test_ai_knowledge_search.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python3
 from __future__ import annotations
 
+import hashlib
+import hmac
 import json
 import os
 import subprocess
@@ -12,9 +14,9 @@ ROOT = Path(__file__).resolve().parents[1]
 SCRIPT = ROOT / "bin" / "ai-knowledge-search"
 
 
-def run(*args: str, cwd: Path | None = None, check: bool = True) -> subprocess.CompletedProcess[str]:
+def run(*args: str, cwd: Path | None = None, check: bool = True, env: dict[str, str] | None = None) -> subprocess.CompletedProcess[str]:
     result = subprocess.run(
-        [*args], cwd=cwd, text=True, capture_output=True, check=False
+        [*args], cwd=cwd, env=env, text=True, capture_output=True, check=False
     )
     if check and result.returncode != 0:
         raise AssertionError(
@@ -33,13 +35,33 @@ def make_ai(project: Path, project_id: str) -> None:
     )
 
 
+def make_key(path: Path) -> bytes:
+    value = b"s" * 64
+    path.write_bytes(value + b"\n")
+    if os.name == "posix":
+        path.chmod(0o600)
+    return value
+
+
+def project_ref(key: bytes, project_id: str) -> str:
+    payload = f"project\0{project_id}".encode("utf-8")
+    return hmac.new(key, payload, hashlib.sha256).hexdigest()[:20]
+
+
 def main() -> int:
     assert SCRIPT.is_file(), SCRIPT
 
     with tempfile.TemporaryDirectory() as directory:
         root = Path(directory)
+        key_file = root / "redaction.key"
+        key = make_key(key_file)
+        current_id = "github.com/example/current"
+        other_id = "github.com/example/other"
+        current_ref = project_ref(key, current_id)
+        other_ref = project_ref(key, other_id)
+
         current = root / "current"
-        make_ai(current, "github.com/example/current")
+        make_ai(current, current_id)
         (current / ".ai" / "knowledge" / "local.md").write_text(
             "# Atomic publish\n\nUse an atomic tree after validation.\n",
             encoding="utf-8",
@@ -50,19 +72,21 @@ def main() -> int:
         )
 
         repository = root / "central"
-        other = repository / "projects" / "other--123"
-        make_ai(other, "ignored")
-        # Collector copies the contents of .ai directly into projects/<key>/.
-        copied = repository / "projects" / "other--123"
-        (copied / "knowledge").mkdir(parents=True, exist_ok=True)
-        (copied / "knowledge" / "remote.md").write_text(
+        other = repository / "projects" / other_ref
+        (other / "knowledge").mkdir(parents=True)
+        (other / "knowledge" / "a1b2c3d4e5f6a7b8c9d0.md").write_text(
             "# Cross project\n\nAtomic generation prevents partial state.\n",
             encoding="utf-8",
         )
+        (other / "inbox").mkdir(parents=True)
+        (other / "inbox" / "b1b2c3d4e5f6a7b8c9d0.md").write_text(
+            "Remote candidate is still a candidate.\n",
+            encoding="utf-8",
+        )
 
-        duplicate = repository / "projects" / "current--456"
+        duplicate = repository / "projects" / current_ref
         (duplicate / "knowledge").mkdir(parents=True)
-        (duplicate / "knowledge" / "duplicate.md").write_text(
+        (duplicate / "knowledge" / "c1b2c3d4e5f6a7b8c9d0.md").write_text(
             "Atomic current copy should be skipped.\n",
             encoding="utf-8",
         )
@@ -70,16 +94,10 @@ def main() -> int:
         (repository / "index.json").write_text(
             json.dumps(
                 {
-                    "schema_version": 1,
+                    "schema_version": 2,
                     "projects": [
-                        {
-                            "project_id": "github.com/example/other",
-                            "path": "projects/other--123",
-                        },
-                        {
-                            "project_id": "github.com/example/current",
-                            "path": "projects/current--456",
-                        },
+                        {"project_ref": other_ref, "path": f"projects/{other_ref}"},
+                        {"project_ref": current_ref, "path": f"projects/{current_ref}"},
                     ],
                 }
             ),
@@ -92,14 +110,17 @@ def main() -> int:
             "generation",
             "--repository",
             str(repository),
+            "--redaction-key-file",
+            str(key_file),
             "--json",
             cwd=current,
         )
         data = json.loads(result.stdout)
         ids = {item["project_id"] for item in data}
-        assert "github.com/example/current" in ids
-        assert "github.com/example/other" in ids
-        assert len([item for item in data if item["project_id"] == "github.com/example/current"]) == 1
+        assert current_id in ids
+        assert other_ref in ids
+        assert current_ref not in ids
+        assert len([item for item in data if item["project_id"] == current_id]) == 1
         assert all(item["kind"] == "knowledge" for item in data)
 
         inbox = run(
@@ -107,28 +128,78 @@ def main() -> int:
             "candidate",
             "--repository",
             str(repository),
+            "--redaction-key-file",
+            str(key_file),
             "--include-inbox",
             "--json",
             cwd=current,
         )
         inbox_data = json.loads(inbox.stdout)
         assert any(item["kind"] == "inbox" for item in inbox_data)
+        assert any(item["project_id"] == other_ref for item in inbox_data)
 
         env = os.environ.copy()
         env["AI_KNOWLEDGE_REPOSITORY"] = str(repository)
-        from_env = subprocess.run(
-            [str(SCRIPT), "partial", "state", "--json"],
+        env["AI_KNOWLEDGE_REDACTION_KEY_FILE"] = str(key_file)
+        from_env = run(
+            str(SCRIPT), "partial", "state", "--json", cwd=current, env=env
+        )
+        assert any(item["project_id"] == other_ref for item in json.loads(from_env.stdout))
+
+        # Central search requires the local HMAC key; local-only search remains usable.
+        missing_key = run(
+            str(SCRIPT),
+            "atomic",
+            "--repository",
+            str(repository),
+            "--redaction-key-file",
+            str(root / "missing.key"),
+            "--json",
             cwd=current,
-            env=env,
-            text=True,
-            capture_output=True,
             check=False,
         )
-        assert from_env.returncode == 0, from_env.stderr
-        assert any(
-            item["project_id"] == "github.com/example/other"
-            for item in json.loads(from_env.stdout)
+        assert missing_key.returncode != 0
+        assert "redaction key not found" in missing_key.stderr
+
+        local_only = run(
+            str(SCRIPT),
+            "atomic",
+            "--repository",
+            str(root / "no-central"),
+            "--redaction-key-file",
+            str(root / "missing.key"),
+            "--json",
+            cwd=current,
         )
+        assert any(item["project_id"] == current_id for item in json.loads(local_only.stdout))
+
+        # Legacy central indexes are deliberately refused rather than exposing raw identifiers.
+        legacy = root / "legacy"
+        legacy.mkdir()
+        (legacy / "index.json").write_text(
+            json.dumps(
+                {
+                    "schema_version": 1,
+                    "projects": [
+                        {"project_id": other_id, "path": "projects/other--123"}
+                    ],
+                }
+            ),
+            encoding="utf-8",
+        )
+        legacy_result = run(
+            str(SCRIPT),
+            "atomic",
+            "--repository",
+            str(legacy),
+            "--redaction-key-file",
+            str(key_file),
+            "--json",
+            cwd=current,
+            check=False,
+        )
+        assert legacy_result.returncode != 0
+        assert "legacy knowledge index schema 1" in legacy_result.stderr
 
     print("test_ai_knowledge_search: PASS")
     return 0

--- a/tests/test_ai_knowledge_secret_redaction.py
+++ b/tests/test_ai_knowledge_secret_redaction.py
@@ -1,0 +1,64 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import importlib.util
+import tempfile
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "bin" / "ai-knowledge-sync"
+
+
+def load_sync_module():
+    spec = importlib.util.spec_from_file_location("ai_knowledge_sync", SCRIPT)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def main() -> int:
+    module = load_sync_module()
+    key = b"k" * 64
+
+    with tempfile.TemporaryDirectory() as directory:
+        project = Path(directory) / "project"
+        project.mkdir()
+        source = project / ".ai" / "knowledge" / "finding.md"
+
+        # Explicit redaction/pseudonymization must not turn a credential into a
+        # committed placeholder. Secret detection runs on raw text first.
+        for text in (
+            "{{redact:ghp_ABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890}}",
+            "{{private:customer:ghp_ABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890}}",
+        ):
+            try:
+                module.pseudonymize_text(
+                    text,
+                    key=key,
+                    project=project,
+                    project_id="github.com/example/project",
+                    source=source,
+                )
+            except module.SyncError as error:
+                assert "GitHub token detected" in str(error)
+            else:
+                raise AssertionError("secret inside a redaction marker was accepted")
+
+        sanitized = module.pseudonymize_text(
+            "Customer {{private:customer:Example Corporation}}",
+            key=key,
+            project=project,
+            project_id="github.com/example/project",
+            source=source,
+        )
+        assert "Example Corporation" not in sanitized
+        assert sanitized.startswith("Customer <customer:")
+
+    print("test_ai_knowledge_secret_redaction: PASS")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_ai_knowledge_secret_redaction.py
+++ b/tests/test_ai_knowledge_secret_redaction.py
@@ -1,7 +1,8 @@
 #!/usr/bin/env python3
 from __future__ import annotations
 
-import importlib.util
+from importlib.machinery import SourceFileLoader
+from importlib.util import module_from_spec, spec_from_loader
 import tempfile
 from pathlib import Path
 
@@ -11,10 +12,11 @@ SCRIPT = ROOT / "bin" / "ai-knowledge-sync"
 
 
 def load_sync_module():
-    spec = importlib.util.spec_from_file_location("ai_knowledge_sync", SCRIPT)
-    assert spec is not None and spec.loader is not None
-    module = importlib.util.module_from_spec(spec)
-    spec.loader.exec_module(module)
+    loader = SourceFileLoader("ai_knowledge_sync", str(SCRIPT))
+    spec = spec_from_loader(loader.name, loader)
+    assert spec is not None
+    module = module_from_spec(spec)
+    loader.exec_module(module)
     return module
 
 

--- a/tests/test_ai_knowledge_sync.py
+++ b/tests/test_ai_knowledge_sync.py
@@ -2,6 +2,8 @@
 from __future__ import annotations
 
 import json
+import os
+import re
 import subprocess
 import tempfile
 from pathlib import Path
@@ -9,6 +11,9 @@ from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
 SCRIPT = ROOT / "bin" / "ai-knowledge-sync"
+KEYGEN = ROOT / "bin" / "ai-knowledge-keygen"
+PROJECT_REF_RE = re.compile(r"^[0-9a-f]{20}$")
+FILE_REF_RE = re.compile(r"^[0-9a-f]{20}\.(?:md|txt|json|jsonl|toml|yaml|yml)$")
 
 
 def run(*args: str, cwd: Path | None = None, check: bool = True) -> subprocess.CompletedProcess[str]:
@@ -41,7 +46,14 @@ def init_repo(path: Path) -> None:
     git(path, "commit", "-q", "-m", "initial")
 
 
-def write_manifest(project: Path, project_id: str, *, enabled: bool, owner: str = "dotfile-work") -> None:
+def write_manifest(
+    project: Path,
+    project_id: str,
+    *,
+    enabled: bool,
+    include_inbox: bool = False,
+    owner: str = "dotfile-work",
+) -> None:
     ai = project / ".ai"
     (ai / "state").mkdir(parents=True, exist_ok=True)
     (ai / "inbox").mkdir(parents=True, exist_ok=True)
@@ -55,6 +67,7 @@ def write_manifest(project: Path, project_id: str, *, enabled: bool, owner: str 
                 "",
                 "[export]",
                 f"enabled = {'true' if enabled else 'false'}",
+                f"include_inbox = {'true' if include_inbox else 'false'}",
                 "",
             ]
         ),
@@ -62,23 +75,55 @@ def write_manifest(project: Path, project_id: str, *, enabled: bool, owner: str 
     )
 
 
-def make_project(root: Path, name: str, project_id: str, *, enabled: bool = True, owner: str = "dotfile-work") -> Path:
+def make_project(
+    root: Path,
+    name: str,
+    project_id: str,
+    *,
+    enabled: bool = True,
+    include_inbox: bool = False,
+    owner: str = "dotfile-work",
+) -> Path:
     project = root / name
     init_repo(project)
-    write_manifest(project, project_id, enabled=enabled, owner=owner)
+    write_manifest(
+        project,
+        project_id,
+        enabled=enabled,
+        include_inbox=include_inbox,
+        owner=owner,
+    )
     (project / ".ai" / "knowledge" / "finding.md").write_text(
         f"# {name}\n\nReusable finding.\n", encoding="utf-8"
+    )
+    (project / ".ai" / "inbox" / "candidate.md").write_text(
+        f"# {name} candidate\n\nUnverified finding.\n", encoding="utf-8"
     )
     return project
 
 
-def sync(source: Path, repository: Path, *, check: bool = True) -> subprocess.CompletedProcess[str]:
+def make_key(path: Path) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("k" * 64 + "\n", encoding="utf-8")
+    if os.name == "posix":
+        path.chmod(0o600)
+
+
+def sync(
+    source: Path,
+    repository: Path,
+    key: Path,
+    *,
+    check: bool = True,
+) -> subprocess.CompletedProcess[str]:
     return run(
         str(SCRIPT),
         "--source-root",
         str(source),
         "--repository",
         str(repository),
+        "--redaction-key-file",
+        str(key),
         "--no-push",
         check=check,
     )
@@ -88,19 +133,30 @@ def index(repository: Path) -> dict[str, object]:
     return json.loads((repository / "index.json").read_text(encoding="utf-8"))
 
 
+def exported_files(repository: Path) -> list[Path]:
+    return sorted(path for path in (repository / "projects").rglob("*") if path.is_file())
+
+
 def main() -> int:
     assert SCRIPT.is_file(), SCRIPT
+    assert KEYGEN.is_file(), KEYGEN
 
     with tempfile.TemporaryDirectory() as directory:
         root = Path(directory)
         source = root / "prog"
         source.mkdir()
+        key = root / "config" / "redaction.key"
+        make_key(key)
 
         project_a = make_project(
             source, "project-a", "github.com/example/project-a", enabled=True
         )
         project_b = make_project(
-            source, "project-b", "github.com/example/project-b", enabled=True
+            source,
+            "project-b",
+            "github.com/example/project-b",
+            enabled=True,
+            include_inbox=True,
         )
         make_project(
             source,
@@ -117,60 +173,163 @@ def main() -> int:
         )
         assert nested.is_dir()
 
+        (project_a / ".ai" / "knowledge" / "finding.md").write_text(
+            "\n".join(
+                [
+                    "# Sanitized reusable finding",
+                    "",
+                    "Customer {{private:customer:Acme Corporation}} hit a reusable lock pattern.",
+                    "Ticket {{redact:INC-12345}} supplied the original evidence.",
+                    f"Local path: {project_a}/src/Worker.php",
+                    "Project metadata: github.com/example/project-a",
+                    "",
+                ]
+            ),
+            encoding="utf-8",
+        )
+        # State is local durable state, not an export source. Secrets here must not be copied.
+        (project_a / ".ai" / "state" / "qcd-observations.jsonl").write_text(
+            '{"token":"state-only-secret-value"}\n', encoding="utf-8"
+        )
+
         # Keep the central private repository under the same ~/prog root to verify self-skip.
         repository = source / "ai-knowledge-private"
         init_repo(repository)
 
-        first = sync(source, repository)
-        assert "projects synced: 2" in first.stdout
+        first = sync(source, repository, key)
+        assert "projects exported: 2" in first.stdout
         data = index(repository)
+        assert data["schema_version"] == 2
         projects = data["projects"]
         assert isinstance(projects, list) and len(projects) == 2
-        ids = {item["project_id"] for item in projects}
-        assert ids == {
-            "github.com/example/project-a",
-            "github.com/example/project-b",
-        }
-        for item in projects:
-            copied = repository / item["path"] / "knowledge" / "finding.md"
-            assert copied.is_file(), copied
+        assert all(set(item) == {"path", "project_ref"} for item in projects)
+        assert all(PROJECT_REF_RE.fullmatch(item["project_ref"]) for item in projects)
+        assert all(item["path"] == f"projects/{item['project_ref']}" for item in projects)
+        index_text = (repository / "index.json").read_text(encoding="utf-8")
+        assert "github.com/example/project-a" not in index_text
+        assert "github.com/example/project-b" not in index_text
+        assert "project-a" not in index_text
+        assert "project-b" not in index_text
+
+        files = exported_files(repository)
+        assert files
+        assert all(FILE_REF_RE.fullmatch(path.name) for path in files)
+        assert not any("state" in path.parts for path in files)
+        assert sum("inbox" in path.parts for path in files) == 1
+        assert sum("knowledge" in path.parts for path in files) == 2
+
+        corpus = "\n".join(path.read_text(encoding="utf-8") for path in files)
+        assert "Acme Corporation" not in corpus
+        assert "INC-12345" not in corpus
+        assert "github.com/example/project-a" not in corpus
+        assert str(project_a) not in corpus
+        assert "state-only-secret-value" not in corpus
+        assert re.search(r"<customer:[0-9a-f]{12}>", corpus)
+        assert "<redacted>" in corpus
+        assert "$PROJECT/src/Worker.php" in corpus
+        assert re.search(r"<project:[0-9a-f]{20}>", corpus)
 
         first_commit_count = int(git(repository, "rev-list", "--count", "HEAD").stdout)
-        second = sync(source, repository)
+        second = sync(source, repository, key)
         assert "committed: no" in second.stdout
         assert int(git(repository, "rev-list", "--count", "HEAD").stdout) == first_commit_count
 
-        # Opting out removes only the previously managed current-tree copy.
-        previous_b_path = next(
-            item["path"]
-            for item in projects
-            if item["project_id"] == "github.com/example/project-b"
-        )
+        # Opting out removes only the previously managed sanitized export.
+        previous_paths = {item["path"] for item in projects}
         write_manifest(
-            project_b, "github.com/example/project-b", enabled=False
+            project_b,
+            "github.com/example/project-b",
+            enabled=False,
+            include_inbox=True,
         )
-        sync(source, repository)
+        sync(source, repository, key)
         data = index(repository)
-        assert [item["project_id"] for item in data["projects"]] == [
-            "github.com/example/project-a"
-        ]
-        assert not (repository / previous_b_path).exists()
+        assert len(data["projects"]) == 1
+        remaining_paths = {item["path"] for item in data["projects"]}
+        assert len(previous_paths - remaining_paths) == 1
+        assert not (repository / next(iter(previous_paths - remaining_paths))).exists()
 
-        # A selected project containing sensitive-looking files fails before destination mutation.
-        (project_a / ".ai" / ".env").write_text("TOKEN=do-not-copy\n", encoding="utf-8")
+        # Secret-bearing exportable content fails before destination mutation.
+        secret_file = project_a / ".ai" / "knowledge" / "secret.md"
+        secret_file.write_text("password=super-secret-value-123\n", encoding="utf-8")
         before = git(repository, "rev-parse", "HEAD").stdout.strip()
-        rejected = sync(source, repository, check=False)
+        rejected = sync(source, repository, key, check=False)
         assert rejected.returncode != 0
-        assert "sensitive-looking path" in rejected.stderr
+        assert "credential assignment detected" in rejected.stderr
         assert git(repository, "rev-parse", "HEAD").stdout.strip() == before
         assert git(repository, "status", "--porcelain").stdout.strip() == ""
-        (project_a / ".ai" / ".env").unlink()
+        secret_file.unlink()
+
+        entropy_file = project_a / ".ai" / "knowledge" / "entropy.md"
+        entropy_file.write_text(
+            "Standalone value: AbCdEfGhIjKlMnOpQrStUvWxYz0123456789_+/=aBcDeFgHiJ\n",
+            encoding="utf-8",
+        )
+        entropy_rejected = sync(source, repository, key, check=False)
+        assert entropy_rejected.returncode != 0
+        assert "high-entropy token detected" in entropy_rejected.stderr
+        entropy_file.unlink()
+
+        # Explicit private markers are the only supported deterministic pseudonymization input.
+        malformed = project_a / ".ai" / "knowledge" / "malformed.md"
+        malformed.write_text("{{private:customer}}\n", encoding="utf-8")
+        rejected = sync(source, repository, key, check=False)
+        assert rejected.returncode != 0
+        assert "malformed redaction marker" in rejected.stderr
+        malformed.unlink()
+
+        # Legacy schema 1 is refused because a normal commit cannot sanitize Git history.
+        legacy = root / "legacy-central"
+        init_repo(legacy)
+        (legacy / "index.json").write_text(
+            json.dumps(
+                {
+                    "schema_version": 1,
+                    "projects": [
+                        {
+                            "project_id": "github.com/example/leaked-name",
+                            "path": "projects/leaked-name--123",
+                        }
+                    ],
+                }
+            ),
+            encoding="utf-8",
+        )
+        git(legacy, "add", "--", "index.json")
+        git(legacy, "commit", "-q", "-m", "legacy")
+        legacy_rejected = sync(source, legacy, key, check=False)
+        assert legacy_rejected.returncode != 0
+        assert "legacy knowledge index schema 1" in legacy_rejected.stderr
+
+        # Missing or weak keys fail before any export.
+        missing = root / "missing.key"
+        key_rejected = sync(source, repository, missing, check=False)
+        assert key_rejected.returncode != 0
+        assert "redaction key not found" in key_rejected.stderr
+        weak = root / "weak.key"
+        weak.write_text("too-short\n", encoding="utf-8")
+        if os.name == "posix":
+            weak.chmod(0o600)
+        weak_rejected = sync(source, repository, weak, check=False)
+        assert weak_rejected.returncode != 0
+        assert "at least 32 bytes" in weak_rejected.stderr
 
         # A dirty central repository is never overwritten.
         (repository / "local-note.txt").write_text("unsaved\n", encoding="utf-8")
-        dirty = sync(source, repository, check=False)
+        dirty = sync(source, repository, key, check=False)
         assert dirty.returncode != 0
         assert "uncommitted changes" in dirty.stderr
+
+        # Key generation is create-only and produces a private file.
+        generated = root / "new-config" / "knowledge.key"
+        generated_result = run(str(KEYGEN), "--path", str(generated))
+        assert generated_result.returncode == 0
+        assert len(generated.read_text(encoding="utf-8").strip()) == 64
+        if os.name == "posix":
+            assert generated.stat().st_mode & 0o077 == 0
+        generated_again = run(str(KEYGEN), "--path", str(generated), check=False)
+        assert generated_again.returncode != 0
+        assert "refusing to overwrite existing key" in generated_again.stderr
 
     print("test_ai_knowledge_sync: PASS")
     return 0


### PR DESCRIPTION
## Summary
- export a sanitized view instead of copying managed `.ai/` trees into the aggregate
- export `.ai/knowledge/` by default, gate `.ai/inbox/` behind `export.include_inbox = true`, and never export `.ai/state/` or `manifest.toml`
- pseudonymize project IDs and source file names with a local HMAC key
- fail closed on recognized secrets and suspicious high-entropy tokens
- scan raw text before redaction so secrets cannot be hidden inside `{{private:...}}` / `{{redact:...}}`
- support explicit confidential redaction with `{{private:<kind>:<value>}}` and non-correlatable redaction with `{{redact:<value>}}`
- reject legacy schema-1 aggregate repositories because a normal follow-up commit cannot sanitize prior Git history
- document key handling, private-repository controls, migration, and incident response

## Security model
- secrets are rejected rather than masked and committed
- central `index.json` schema v2 contains only opaque project references
- source file/directory names are not exported
- absolute project/home paths are normalized in exported content
- deterministic confidential pseudonyms use HMAC-SHA256 with a local-only key generated by `ai-knowledge-keygen`

## Migration
Existing schema-1 aggregates are intentionally rejected. Recreate the private knowledge repository (preferred if disposable) or audit and rewrite/purge its Git history before scheduled sync is re-enabled.

## Test
- `python3 tests/test_ai_knowledge_sync.py`
- `python3 tests/test_ai_knowledge_search.py`
- `python3 tests/test_ai_knowledge_secret_redaction.py`
- `python3 tests/test_ai_knowledge_policy.py`
- `bash tests/test_ai_init_project.sh`
- Python compile checks for sync/search/keygen

`generated-assets` passes on GitHub Actions with the new secret-redaction bypass regression.