### PR TITLE
fix: preserve unmanaged symlinks during uninstall

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -622,11 +622,25 @@ _csl_dir_all_stale() {
 cleanup_legacy_claude_skill_tiers() {
     _skills_dir="${HOME}/.claude/skills"
     [ -d "$_skills_dir" ] || return 0
+
     for _entry in "$_skills_dir"/*; do
-        [ -d "$_entry" ] || continue
         case "$(basename "$_entry")" in
             1-core|2-domain|3-task|4-utility)
-                _remove_stale "$_entry" "旧スキル構造: $(basename "$_entry")" rf
+                if [ -L "$_entry" ]; then
+                    remove_dotfiles_link "$_entry" "旧スキル構造: $(basename "$_entry")"
+                    continue
+                fi
+                [ -d "$_entry" ] || continue
+
+                _legacy_links=$(mktemp)
+                _TMPFILES="$_TMPFILES $_legacy_links"
+                find "$_entry" -type l -print > "$_legacy_links" 2>/dev/null || true
+                while IFS= read -r _legacy_link; do
+                    [ -n "$_legacy_link" ] || continue
+                    remove_dotfiles_link \
+                        "$_legacy_link" \
+                        "旧スキル構造リンク: ${_legacy_link#"$HOME"/}"
+                done < "$_legacy_links"
                 ;;
         esac
     done
@@ -1901,7 +1915,7 @@ dotfiles インストーラー - dotfilesのシンボリックリンクを作成
     ./install.sh              # 対話的にインストール
     ./install.sh -f           # すべてインストール(現在のシェルのみ)
     ./install.sh -n           # インストール内容をプレビュー
-    ./install.sh -u           # すべてのシンボリックリンクを削除
+    ./install.sh -u           # このリポジトリが管理するシンボリックリンクを削除
 EOF
 }
 

--- a/tests/test_issue_regressions.py
+++ b/tests/test_issue_regressions.py
@@ -50,6 +50,42 @@ def test_uninstall_before_install_returns_zero(tmp_path: Path) -> None:
     assert result.returncode == 0, result.stdout + result.stderr
 
 
+def test_uninstall_preserves_unmanaged_symlinks(tmp_path: Path) -> None:
+    """Uninstall may remove dotfiles-owned links, never unrelated HOME links."""
+    home = tmp_path / "home"
+    tier = home / ".claude" / "skills" / "1-core"
+    tier.mkdir(parents=True)
+
+    external_target = tmp_path / "external-skill"
+    external_target.mkdir()
+    unrelated_home_link = home / "unrelated-home-link"
+    unrelated_tier_link = tier / "unrelated-tier-link"
+    unrelated_home_link.symlink_to(external_target, target_is_directory=True)
+    unrelated_tier_link.symlink_to(external_target, target_is_directory=True)
+
+    managed_target = REPO_ROOT / "common" / "skills" / "tdd"
+    managed_tier_link = tier / "managed-tier-link"
+    managed_tier_link.symlink_to(managed_target, target_is_directory=True)
+
+    env = {**os.environ, "HOME": str(home)}
+    result = subprocess.run(
+        ["sh", str(INSTALL_SH), "-u", "-f"],
+        cwd=REPO_ROOT,
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert unrelated_home_link.is_symlink()
+    assert unrelated_tier_link.is_symlink()
+    assert unrelated_home_link.resolve() == external_target.resolve()
+    assert unrelated_tier_link.resolve() == external_target.resolve()
+    assert not managed_tier_link.exists()
+    assert not managed_tier_link.is_symlink()
+
+
 def test_repository_setup_is_explicit_not_a_post_tool_side_effect() -> None:
     """GitHub repository mutations must go through the explicit gh-setup-repo CLI."""
     settings = json.loads(CLAUDE_SETTINGS.read_text(encoding="utf-8"))


### PR DESCRIPTION
## Reproduction

The reported blanket `$HOME` symlink deletion is not present in current `main`: normal uninstall paths validate the expected source or require the link target to be inside this repository.

A narrower ownership bug is reproducible in the same uninstall flow: `cleanup_legacy_claude_skill_tiers` recursively removed the entire `~/.claude/skills/{1-core,2-domain,3-task,4-utility}` directory with `rm -rf`. Any unrelated symlink or regular file stored inside one of those legacy tier directories was therefore removed as collateral damage.

## Fix

- stop recursively deleting legacy Claude skill tier directories
- inspect symlinks inside the legacy tiers and remove only links whose target is inside `DOTFILES_DIR`
- preserve unrelated symlinks, regular files, and the containing directory
- clarify the uninstall help text to describe repository-managed links rather than "all symlinks"

## Regression coverage

`test_uninstall_preserves_unmanaged_symlinks` creates:

- an unrelated symlink directly under `$HOME`
- an unrelated symlink inside `~/.claude/skills/1-core`
- a dotfiles-owned symlink inside the same legacy tier

After `install.sh -u -f`, both unrelated links must remain and the dotfiles-owned legacy link must be removed.

## Verification

Verify run #96 passed:
- generated-assets: success
- regression: success
- hook tests: success
- Codex hook tests: success
- CLI tests: success
- shell lint tests: success
- installer and asset pipeline tests: success

Closes #441